### PR TITLE
Update isUUID.js

### DIFF
--- a/src/utils/isUUID.js
+++ b/src/utils/isUUID.js
@@ -1,4 +1,4 @@
 module.exports = (uuid) => {
-  const regexp = /[0-9a-fA-F]{8}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{4}(-)?[0-9a-fA-F]{12}/gm;
+  const regexp = /[0-9a-f]{8}(-)?[0-9a-f]{4}(-)?[0-9a-f]{4}(-)?[0-9a-f]{4}(-)?[0-9a-f]{12}/gim;
   return regexp.test(uuid);
 };


### PR DESCRIPTION
Used i flag instead of a-f and A-F in regexp

**Please describe changes**
Used i flag instead of a-f and A-F when matching uuid ( less repetition in code )

*Description*

- [x] I've added new features (methods or parameters)
- [ ] I've fixed bug (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.