### PR TITLE
Options parameter in Client constructor for cache limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,20 @@
 ``` js
 const Hypixel = require('hypixel-api-reborn');
 
-/* Parameters:
+/* 
+Parameters:
 API Key (String)
 options (Object)
 options.cache (false by default) - Enables/Disables Request Caching
-options.cacheTime (60 by default) - Amount of time in seconds to cache the request. 
+options.cacheTime (60 by default) - Amount of time in seconds to cache the request.
+options.cacheLimit (0 by default) - The limit of how many results will be cached (set 0 for no limit)
 */
 
-//Enables caching with a max age of 30 seconds
+//Enables caching with a max age of 30 seconds and a limit of 5 cached results
 const options = {
     cache: true,
-    cacheTime: 30
-    };
+    cacheTime: 30,
+    cacheLimit: 5
+};
 const hypixel = new Hypixel.Client('API-KEY', options);
 ```

--- a/src/Client.js
+++ b/src/Client.js
@@ -7,7 +7,7 @@ const Errors = require('./Errors');
 const cached = {};
 
 class Client {
-  constructor (key, options = { cache: false, cacheTime: 60 }) {
+  constructor (key, options = { cache: false, cacheTime: 60, cacheLimit: 0 }) {
     if (!key) throw new Error(Errors.NO_API_KEY);
     if (typeof key !== 'string') throw new Error(Errors.KEY_MUST_BE_A_STRING);
     this.options = options || {};
@@ -26,7 +26,8 @@ class Client {
     if (res.status === 403) throw new Error(Errors.ERROR_CODE_CAUSE.replace(/{code}/g, '403 Forbidden').replace(/{cause}/g, 'Invalid API Key'));
     if (res.status !== 200) throw new Error(Errors.ERROR_STATUSTEXT.replace(/{statustext}/g, res.statusText));
     if (this.options.cache) {
-      cached[url] = parsedRes;
+      if (this.options.cacheLimit < 1) cached[url] = parsedRes;
+      else if (Object.keys(this.options).length < this.options.cacheLimit) cached[url] = parsedRes;
       setTimeout(() => delete cached[url], 1000 * ((typeof this.options.cacheTime === 'number' ? this.options.cacheTime : null) || 60));
     }
     return parsedRes;

--- a/src/Client.js
+++ b/src/Client.js
@@ -27,7 +27,7 @@ class Client {
     if (res.status !== 200) throw new Error(Errors.ERROR_STATUSTEXT.replace(/{statustext}/g, res.statusText));
     if (this.options.cache) {
       if (this.options.cacheLimit < 1) cached[url] = parsedRes;
-      else if (Object.keys(this.options).length < this.options.cacheLimit) cached[url] = parsedRes;
+      else if (Object.keys(cached).length < this.options.cacheLimit) cached[url] = parsedRes;
       setTimeout(() => delete cached[url], 1000 * ((typeof this.options.cacheTime === 'number' ? this.options.cacheTime : null) || 60));
     }
     return parsedRes;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,6 +8,7 @@ type BEDWARS_PRESTIGE = 'Iron' | 'Gold' | 'Diamond' | 'Emerald' | 'Sapphire' | '
 interface clientOptions {
     cache: boolean;
     cacheTime: number;
+    cacheLimit: number;
 }
 declare module 'hypixel-api-reborn' {
     export const version: string;


### PR DESCRIPTION
**Please describe changes**

The options.cacheLimit parameter limits how many results will be cached at once, and defaults to 0 (no limit)

I couldn't test the changes because npm run test didn't work and froze command prompt every time I ran it

*Description*

- [x] I've added new features. (methods or parameters)
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [ ] I've tested my code. (`npm run test`)
