### PR TITLE
fix maxLevel in getLevelByXp and improve regex in isUUID

### DIFF
--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -30,10 +30,13 @@ module.exports = {
         xpTable = constants.leveling_xp;
     }
 
+    const maxLevel = Math.max(...Object.keys(xpTable));
+
     if (isNaN(xp)) {
       return {
         xp: 0,
         level: 0,
+        maxLevel: maxLevel,
         xpCurrent: 0,
         xpForNext: xpTable[1],
         progress: 0
@@ -43,8 +46,6 @@ module.exports = {
     let xpTotal = 0;
     let level = 0;
     let xpForNext = 0;
-
-    const maxLevel = Math.max(...Object.keys(xpTable));
 
     for (let x = 1; x <= maxLevel; x++) {
       xpTotal += xpTable[x];

--- a/src/utils/isUUID.js
+++ b/src/utils/isUUID.js
@@ -1,5 +1,5 @@
 module.exports = (uuid) => {
-  const regexp = /[0-9a-f]{8}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{4}[0-9a-f]{12}/gim;
+  const regexp = /^[0-9a-f]{32}$/i;
   uuid = uuid.replace(/-/g, '');
   return regexp.test(uuid);
 };


### PR DESCRIPTION
**Please describe changes**
 - getLevelByXp: now returns maxLevel in case the input xp is undefined
 - isUUID: simplified the regex and made it check the whole input string

*Description*

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)