### PR TITLE
handling of wrong user input

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -44,17 +44,16 @@ class Client {
     return parsedRes;
   }
 
-  async getPlayer (query, options = { guild: false }) {
-    if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
-    const Player = require('./structures/Player');
-
+  async getPlayer (query, options = {}) {
     query = await toUuid(query);
-
+    if (typeof options !== 'object') throw new Error(Errors.OPTIONS_MUST_BE_AN_OBJECT);
+    const { guild = false } = options;
+    const Player = require('./structures/Player');
     const res = await this._makeRequest(`/player?uuid=${query}`);
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
     }
-    if (options.guild) {
+    if (guild) {
       const guildRes = await this._makeRequest(`/guild?player=${query}`);
       if (!guildRes.success) {
         throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, guildRes.cause));
@@ -67,7 +66,7 @@ class Client {
   async getGuild (searchParameter, query) {
     if (!query) throw new Error(Errors.NO_GUILD_QUERY);
     const Guild = require('./structures/Guild/Guild');
-    var res;
+    let res;
     switch (searchParameter) {
       case 'id': {
         if (!isGuildID(query)) {
@@ -102,11 +101,8 @@ class Client {
   }
 
   async getFriends (query) {
-    if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
-    const Friend = require('./structures/Friend');
-
     query = await toUuid(query);
-
+    const Friend = require('./structures/Friend');
     const res = await this._makeRequest(`/friends?uuid=${query}`);
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -121,7 +117,6 @@ class Client {
 
   async getWatchdogStats () {
     const WatchdogStats = require('./structures/Watchdog/Stats');
-
     const res = await this._makeRequest('/watchdogstats');
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -132,7 +127,6 @@ class Client {
 
   async getBoosters () {
     const Booster = require('./structures/Boosters/Booster');
-
     const res = await this._makeRequest('/boosters');
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -142,9 +136,8 @@ class Client {
   }
 
   async getSkyblockProfiles (query) {
-    const SkyblockProfile = require('./structures/SkyBlock/SkyblockProfile');
-    if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
     query = await toUuid(query);
+    const SkyblockProfile = require('./structures/SkyBlock/SkyblockProfile');
     const res = await this._makeRequest(`/skyblock/profiles?uuid=${query}`);
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -191,9 +184,8 @@ class Client {
   }
 
   async getSkyblockAuctionsByPlayer (query) {
-    if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
-    const Auction = require('./structures/SkyBlock/Auctions/Auction');
     query = await toUuid(query);
+    const Auction = require('./structures/SkyBlock/Auctions/Auction');
     const res = await this._makeRequest(`/skyblock/auction?player=${query}`);
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -204,7 +196,6 @@ class Client {
 
   async getSkyblockBazaar () {
     const Product = require('./structures/SkyBlock/Bazzar/Product');
-
     const res = await this._makeRequest('/skyblock/bazaar');
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
@@ -220,8 +211,8 @@ class Client {
   }
 
   async getStatus (query) {
-    const Status = require('./structures/Status');
     query = await toUuid(query);
+    const Status = require('./structures/Status');
     const res = await this._makeRequest(`/status?uuid=${query}`);
     if (!res.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));

--- a/src/Client.js
+++ b/src/Client.js
@@ -12,18 +12,19 @@ class Client {
     if (typeof key !== 'string') throw new Error(Errors.KEY_MUST_BE_A_STRING);
 
     this.options = {
-      cache: options.cache || false,
-      cacheTime: options.cacheTime || 60,
-      cacheSize: options.cacheSize || -1
+      cache: options.cache === undefined ? false : options.cache,
+      cacheTime: options.cacheTime === undefined ? 60 : options.cacheTime,
+      cacheSize: options.cacheSize === undefined ? -1 : options.cacheSize
     };
     this.key = key;
-    this._validateOptions();
+    this._validateOptions(options);
   }
 
-  _validateOptions (options = this.options) {
+  _validateOptions (options) {
     if (typeof options !== 'object') throw new Error(Errors.OPTIONS_MUST_BE_AN_OBJECT);
-    if (typeof options.cacheTime !== 'number') throw new Error(Errors.CACHE_TIME_MUST_BE_A_NUMBER);
-    if (typeof options.cacheSize !== 'number') throw new Error(Errors.CACHE_LIMIT_MUST_BE_A_NUMBER);
+    if (typeof this.options.cache !== 'boolean') throw new Error(Errors.CACHE_MUST_BE_A_BOOLEAN);
+    if (typeof this.options.cacheTime !== 'number') throw new Error(Errors.CACHE_TIME_MUST_BE_A_NUMBER);
+    if (typeof this.options.cacheSize !== 'number') throw new Error(Errors.CACHE_LIMIT_MUST_BE_A_NUMBER);
   }
 
   async _makeRequest (url) {

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -5,6 +5,7 @@ module.exports = {
   ERROR_STATUSTEXT: '[hypixel-api-reborn] {statustext}! For help join our Discord Server https://discord.gg/NSEBNMM',
   KEY_MUST_BE_A_STRING: '[hypixel-api-reborn] Specified API Key must be a string! For help join our Discord Server https://discord.gg/NSEBNMM',
   OPTIONS_MUST_BE_AN_OBJECT: '[hypixel-api-reborn] Options must be an object! For help join our Discord Server https://discord.gg/NSEBNMM',
+  CACHE_MUST_BE_A_BOOLEAN: '[hypixel-api-reborn] Cache must be a boolean! For help join our Discord Server https://discord.gg/NSEBNMM',
   CACHE_TIME_MUST_BE_A_NUMBER: '[hypixel-api-reborn] Cache Time must be a number! For help join our Discord Server https://discord.gg/NSEBNMM',
   CACHE_LIMIT_MUST_BE_A_NUMBER: '[hypixel-api-reborn] Cache Limit must be a number! For help join our Discord Server https://discord.gg/NSEBNMM',
   NO_NICKNAME_UUID: '[hypixel-api-reborn] No nickname or uuid specified.',

--- a/src/structures/Guild/GuildMember.js
+++ b/src/structures/Guild/GuildMember.js
@@ -5,8 +5,8 @@ class GuildMember {
     this.questParticipation = data.questParticipation || 0;
     this.rank = data.rank;
     this.mutedUntil = data.mutedTill ? data.mutedTill : null;
-    var gexp = 0;
-    var history = [];
+    let gexp = 0;
+    const history = [];
     if (Object.keys(data.expHistory).length) {
       for (const day in data.expHistory) {
         gexp += data.expHistory[day];

--- a/src/structures/MiniGames/BedWars.js
+++ b/src/structures/MiniGames/BedWars.js
@@ -107,7 +107,7 @@ const HIGHEST_PRESTIGE = 10;
 function getExpForLevel (level) {
   if (level === 0) return 0;
 
-  var respectedLevel = getLevelRespectingPrestige(level);
+  const respectedLevel = getLevelRespectingPrestige(level);
   if (respectedLevel > EASY_LEVELS) {
     return 5000;
   }
@@ -146,12 +146,12 @@ function getLevelRespectingPrestige (level) {
  * @returns {number}
  */
 function getLevelForExp (exp) {
-  var prestiges = Math.floor(exp / XP_PER_PRESTIGE);
-  var level = prestiges * LEVELS_PER_PRESTIGE;
-  var expWithoutPrestiges = exp - (prestiges * XP_PER_PRESTIGE);
+  const prestiges = Math.floor(exp / XP_PER_PRESTIGE);
+  let level = prestiges * LEVELS_PER_PRESTIGE;
+  let expWithoutPrestiges = exp - (prestiges * XP_PER_PRESTIGE);
 
   for (let i = 1; i <= EASY_LEVELS; ++i) {
-    var expForEasyLevel = getExpForLevel(i);
+    const expForEasyLevel = getExpForLevel(i);
     if (expWithoutPrestiges < expForEasyLevel) {
       break;
     }

--- a/src/structures/MiniGames/SkyWars.js
+++ b/src/structures/MiniGames/SkyWars.js
@@ -132,12 +132,12 @@ function getSkyWarsPrestige (level) {
 }
 function getSkyWarsLevel (xp) {
   if (xp < 20) return 1;
-  var totalXp = [20, 70, 150, 250, 500, 1000, 2000, 3500, 6000, 10000, 15000];
-  var exactLevel = 0;
+  const totalXp = [20, 70, 150, 250, 500, 1000, 2000, 3500, 6000, 10000, 15000];
+  let exactLevel = 0;
   if (xp >= 15000) {
     exactLevel = (xp - 15000) / 10000 + 12;
   } else {
-    var c = 0;
+    let c = 0;
     // eslint-disable-next-line no-unmodified-loop-condition
     while (xp >= 0) {
       if (xp - totalXp[c] >= 0) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,7 +28,8 @@ declare module 'hypixel-api-reborn' {
         INVALID_RESPONSE_BODY: string,
         OPTIONS_MUST_BE_AN_OBJECT: string,
         CACHE_TIME_MUST_BE_A_NUMBER: string,
-        CACHE_LIMIT_MUST_BE_A_NUMBER: string
+        CACHE_LIMIT_MUST_BE_A_NUMBER: string,
+        CACHE_MUST_BE_A_BOOLEAN: string
     }
     export class Client {
         constructor(key: string, options?: clientOptions);


### PR DESCRIPTION
Do not merge before #33 as that implements the !query check in isUuid(). As an alternative I or someone else can open a separate PR just for isUuid() to insert `if (!input) throw new Error(Errors.NO_NICKNAME_UUID)` before the typeof check

**Please describe changes**
 - Changed default value assignment in client options to check for 'undefined' rather than 'or' to prevent false values being silently ignored
 - Similar handling of wrong user input and default values in <Client>.getPlayer() as in the client options
 - Removed the last few occurrences of 'var' in the code
 - Removed `if (!query) throw new Error(Errors.NO_NICKNAME_UUID)` in the client methods as moving it into toUuid() would be more concise with the typeof check there. Technically it is not needed anymore to prevent errors as typeof prevents the input of undefined values further in the code but it is nice to have as a more precise user feedback and removing it completely would even be a breaking change

*Description*

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)