### PR TITLE
Auto parse time and recent games

### DIFF
--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -15,5 +15,5 @@ module.exports = async function (query, options = { guild: false }) {
     }
     res.player.guild = guildRes.guild;
   }
-  return new Player(res.player);
+  return new Player(res.player, this);
 };

--- a/src/API/getRecentGames.js
+++ b/src/API/getRecentGames.js
@@ -1,0 +1,17 @@
+const Errors = require('../Errors');
+const toUuid = require('../utils/toUuid');
+const day3 = 1000 * 60 * 60 * 24 * 3;
+module.exports = async function (query, playerData) {
+  if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
+  const RecentGame = require('../structures/RecentGame');
+
+  query = await toUuid(query);
+
+  const res = await this._makeRequest(`/recentgames?uuid=${query}`);
+  if (res.games === []) {
+    if (!playerData) throw new Error(Errors.PLAYER_IS_INACTIVE);
+    if (new Date().getTime() - playerData.lastlogin < day3) throw new Error(Errors.PLAYER_DISABLED_ENDPOINT);
+    throw new Error(Errors.PLAYER_IS_INACTIVE);
+  }
+  return res.games.map(x => new RecentGame(x));
+};

--- a/src/API/getRecentGames.js
+++ b/src/API/getRecentGames.js
@@ -10,7 +10,7 @@ module.exports = async function (query, playerData) {
   const res = await this._makeRequest(`/recentgames?uuid=${query}`);
   if (res.games === []) {
     if (!playerData) throw new Error(Errors.PLAYER_IS_INACTIVE);
-    if (new Date().getTime() - playerData.lastlogin < day3) throw new Error(Errors.PLAYER_DISABLED_ENDPOINT);
+    if (new Date().getTime() - playerData.lastLogoutTimestamp < day3) throw new Error(Errors.PLAYER_DISABLED_ENDPOINT);
     throw new Error(Errors.PLAYER_IS_INACTIVE);
   }
   return res.games.map(x => new RecentGame(x));

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -13,6 +13,8 @@ module.exports = {
   UUID_NICKNAME_MUST_BE_A_STRING: '[hypixel-api-reborn] Nickname or uuid must be a string.',
   MALFORMED_UUID: '[hypixel-api-reborn] Malformed UUID!',
   PLAYER_DOES_NOT_EXIST: '[hypixel-api-reborn] Player does not exist.',
+  PLAYER_IS_INACTIVE: '[hypixel-api-reborn] No records of recent games because player hasn\'t been online for more than 3 days or is lacking data to determine the cause of an empty response',
+  PLAYER_DISABLED_ENDPOINT: '[hypixel-api-reborn] Player has disabled this endpoint.',
   NO_GUILD_QUERY: '[hypixel-api-reborn] No guild search query specified.',
   INVALID_GUILD_ID: '[hypixel-api-reborn] Specified Guild ID is invalid.',
   INVALID_GUILD_SEARCH_PARAMETER: '[hypixel-api-reborn] getGuild() searchParameter must be \'id\', \'guild\' or \'player\'.',

--- a/src/structures/Boosters/Booster.js
+++ b/src/structures/Boosters/Booster.js
@@ -6,7 +6,8 @@ class Booster {
     this.amount = data.amount;
     this.originalLength = data.originalLength;
     this.remaining = data.length;
-    this.activated = data.dateActivated;
+    this.activatedTimestamp = data.dateActivated;
+    this.activated = new Date(data.Activated);
     this.game = data.gameType ? new Game(data.gameType) : null;
   }
 }

--- a/src/structures/Friend.js
+++ b/src/structures/Friend.js
@@ -2,7 +2,8 @@ class Friend {
   constructor (data) {
     this.sender = data.uuidSender;
     this.receiver = data.uuidReceiver;
-    this.friendSince = data.started;
+    this.friendSinceTimestamp = data.started;
+    this.friendSince = new Date(data.started);
   }
 }
 

--- a/src/structures/Guild/Guild.js
+++ b/src/structures/Guild/Guild.js
@@ -35,10 +35,12 @@ class Guild {
       if (!data.ranks || !data.ranks.find(r => r.priority === priority)) return null;
       return new GuildRank(data.ranks.find(r => r.priority === priority));
     };
-    this.createdAt = data.created;
+    this.createdAtTimestamp = data.created;
+    this.createdAt = new Date(data.created);
     this.joinable = data.joinable ? data.joinable : false;
     this.publiclyListed = !!data.publiclyListed;
-    this.chatMuteUntil = data.chatMute ? data.chatMute : null;
+    this.chatMuteUntilTimestamp = data.chatMute ? data.chatMute : null;
+    this.chatMuteUntil = data.chatMute ? new Date(data.chatMute) : null;
     this.banner = data.banner ? data.banner : data.banner;
     this.tag = data.tag ? data.tag : null;
     this.tagColor = data.tagColor ? new Color(data.tagColor) : null;

--- a/src/structures/Guild/GuildMember.js
+++ b/src/structures/Guild/GuildMember.js
@@ -1,10 +1,12 @@
 class GuildMember {
   constructor (data) {
     this.uuid = data.uuid;
-    this.joinedAt = data.joined;
+    this.joinedAtTimestamp = data.joined;
+    this.joinedAt = new Date(data.joined);
     this.questParticipation = data.questParticipation || 0;
     this.rank = data.rank;
-    this.mutedUntil = data.mutedTill ? data.mutedTill : null;
+    this.mutedUntilTimestamp = data.mutedTill ? data.mutedTill : null;
+    this.mutedUntil = data.mutedTill ? new Date(data.mutedTill) : null;
     var gexp = 0;
     var history = [];
     if (Object.keys(data.expHistory).length) {

--- a/src/structures/Guild/GuildRank.js
+++ b/src/structures/Guild/GuildRank.js
@@ -3,7 +3,8 @@ class GuildRank {
     this.name = data.name;
     this.default = data.default;
     this.tag = data.tag ? data.tag : null;
-    this.createdAt = data.created;
+    this.createdAtTimestamp = data.created;
+    this.createdAt = new Date(data.created);
     this.priority = data.priority;
   }
 }

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -68,7 +68,7 @@ class Player {
   }
 
   getRecentGames () {
-    return this.getRecentGames(this.uuid, {...this.lastLogoutTimestamp});
+    return this.getRecentGames(this.uuid, {"lastLogoutTimestamp":this.lastLogoutTimestamp});
   }
 }
 

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -68,7 +68,7 @@ class Player {
   }
 
   getRecentGames () {
-    return this.getRecentGames(this.uuid, this);
+    return this.getRecentGames(this.uuid, {...this.lastLogoutTimestamp});
   }
 }
 

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -24,8 +24,12 @@ class Player {
     this.history = data.knownAliases;
     this.rank = getRank(data);
     this.mcVersion = data.mcVersionRp || null;
-    this.lastLogin = data.lastLogin || null;
-    this.firstLogin = data.firstLogin || null;
+    this.lastLoginTimestamp = data.lastLogin || null;
+    this.firstLoginTimestamp = data.firstLogin || null;
+    this.lastLogin = data.lastLogin ? new Date(data.lastLogin) : null;
+    this.lastLogout = data.lastLogout ? new Date(data.lastLogout) : null;
+    this.lastLogoutTimestamp = data.lastLogout || null;
+    this.firstLogin = data.firstLogin ? new Date(data.firstLogin) : null;
     this.recentlyPlayedGame = data.mostRecentGameType ? new Game(data.mostRecentGameType) : null;
     if (this.rank === 'MVP+' || this.rank === 'MVP++') {
       this.plusColor = data.rankPlusColor ? new Color(data.rankPlusColor) : null;
@@ -42,7 +46,7 @@ class Player {
     this.giftsSent = data.giftingMeta ? data.giftingMeta.realBundlesGiven || 0 : null;
     this.giftsReceived = data.giftingMeta ? data.giftingMeta.realBundlesReceived || 0 : null;
 
-    this.isOnline = this.lastLogin > data.lastLogout;
+    this.isOnline = this.lastLoginTimestamp > this.lastLogoutTimestamp;
 
     this.stats = (data.stats ? {
       skywars: (data.stats.SkyWars ? new SkyWars(data.stats.SkyWars) : null),
@@ -61,6 +65,10 @@ class Player {
       blitzsg: (data.stats.HungerGames ? new BlitzSurvivalGames(data.stats.HungerGames) : null),
       arena: (data.stats.Arena ? new ArenaBrawl(data.stats.Arena) : null)
     } : null);
+  }
+
+  getRecentGames () {
+    return this.getRecentGames(this.uuid, this);
   }
 }
 

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -13,12 +13,13 @@ const SmashHeroes = require('./MiniGames/SmashHeroes');
 const VampireZ = require('./MiniGames/VampireZ');
 const BlitzSurvivalGames = require('./MiniGames/BlitzSurvivalGames');
 const ArenaBrawl = require('./MiniGames/ArenaBrawl');
-
+const getRecentGames = require('../API/getRecentGames');
 const Color = require('./Color');
 const Game = require('./Game');
 
 class Player {
-  constructor (data) {
+  constructor (data, fakethis) {
+    this.fakethis = fakethis;
     this.nickname = data.displayname;
     this.uuid = data.uuid;
     this.history = data.knownAliases;
@@ -42,7 +43,6 @@ class Player {
     this.totalExperience = data.networkExp || 0;
     this.level = getPlayerLevel(this.totalExperience) || 0;
     this.socialmedia = getSocialMedia(data.socialMedia) || [];
-
     this.giftsSent = data.giftingMeta ? data.giftingMeta.realBundlesGiven || 0 : null;
     this.giftsReceived = data.giftingMeta ? data.giftingMeta.realBundlesReceived || 0 : null;
 
@@ -68,7 +68,7 @@ class Player {
   }
 
   getRecentGames () {
-    return this.getRecentGames(this.uuid, {"lastLogoutTimestamp":this.lastLogoutTimestamp});
+    return getRecentGames.call(this.fakethis, this.uuid, this);
   }
 }
 

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -19,7 +19,6 @@ const Game = require('./Game');
 
 class Player {
   constructor (data, fakethis) {
-    this.fakethis = fakethis;
     this.nickname = data.displayname;
     this.uuid = data.uuid;
     this.history = data.knownAliases;
@@ -47,6 +46,9 @@ class Player {
     this.giftsReceived = data.giftingMeta ? data.giftingMeta.realBundlesReceived || 0 : null;
 
     this.isOnline = this.lastLoginTimestamp > this.lastLogoutTimestamp;
+    this.getRecentGames = function () {
+      return getRecentGames.call(fakethis, this.uuid, this);
+    };
 
     this.stats = (data.stats ? {
       skywars: (data.stats.SkyWars ? new SkyWars(data.stats.SkyWars) : null),
@@ -65,10 +67,6 @@ class Player {
       blitzsg: (data.stats.HungerGames ? new BlitzSurvivalGames(data.stats.HungerGames) : null),
       arena: (data.stats.Arena ? new ArenaBrawl(data.stats.Arena) : null)
     } : null);
-  }
-
-  getRecentGames () {
-    return getRecentGames.call(this.fakethis, this.uuid, this);
   }
 }
 

--- a/src/structures/RecentGame.js
+++ b/src/structures/RecentGame.js
@@ -1,0 +1,14 @@
+const Game = require('./Game');
+class RecentGame extends Game {
+  constructor (data) {
+    super(data.gameType);
+    this.date = data.date || null;
+    this.at = data.date ? new Date(data.date) : null;
+    this.mode = data.mode || null;
+    this.map = data.map || null;
+    // Per hypixel API docs : if ended isn't present, the game is ONGOING.
+    this.endedAt = new Date(data.ended) || 'ONGOING';
+    this.endedTimestamp = data.ended;
+  }
+}
+module.exports = RecentGame;

--- a/src/structures/SkyBlock/Auctions/Auction.js
+++ b/src/structures/SkyBlock/Auctions/Auction.js
@@ -5,8 +5,10 @@ class Auction {
     this.auctionId = data.uuid || null;
     this.auctioneerUuid = data.auctioneer || null;
     this.coop = data.coop || [];
-    this.auctionStart = data.start || null;
-    this.auctionEnd = data.end || null;
+    this.auctionStartTimestamp = data.start || null;
+    this.auctionStart = data.start ? new Date(data.start) : null;
+    this.auctionEnd = data.end ? new Date(data.end) : null;
+    this.auctionEndTimestamp = data.end || null;
     this.item = data.item_name || null;
     this.itemLore = data.item_lore ? data.item_lore.replace(/§([1-9]|[a-l])|§/gm, '') : null;
     this.startingBid = data.starting_bid || 0;

--- a/src/structures/SkyBlock/Auctions/Bid.js
+++ b/src/structures/SkyBlock/Auctions/Bid.js
@@ -4,6 +4,7 @@ class Bid {
     this.profileId = data.profile_id || null;
     this.amount = data.amount || 0;
     this.timestamp = data.timestamp || null;
+    this.at = data.timestampe ? new Date(data.timestamp) : null;
     this.bidder = data.bidder || null;
   }
 }

--- a/src/structures/SkyBlock/Auctions/Bid.js
+++ b/src/structures/SkyBlock/Auctions/Bid.js
@@ -4,7 +4,7 @@ class Bid {
     this.profileId = data.profile_id || null;
     this.amount = data.amount || 0;
     this.timestamp = data.timestamp || null;
-    this.at = data.timestampe ? new Date(data.timestamp) : null;
+    this.at = data.timestamp ? new Date(data.timestamp) : null;
     this.bidder = data.bidder || null;
   }
 }

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -6,8 +6,11 @@ const objectPath = require('object-path');
 class SkyblockMember {
   constructor (data) {
     this.uuid = data.uuid;
-    this.firstJoin = data.m.first_join;
+    this.firstJoinTimestamp = data.m.first_join;
+    this.firstJoinAt = new Date(data.m.first_join);
     this.lastSave = data.m.last_save;
+    this.lastSaveAt = new Date(data.m.last_save);
+    this.lastDeathAt = new Date(data.m.last_death);
     this.lastDeath = data.m.last_death;
     this.getArmor = async () => {
       const base64 = data.m.inv_armor;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -105,9 +105,13 @@ declare module 'hypixel-api-reborn' {
          */
         public getLeaderboards(options?: methodOptions): Promise<{ ARENA: Leaderboard[], COPS_AND_CRIMS: Leaderboard[], WARLORDS: Leaderboard[], BLITZ_SURVIVAL_GAMES: Leaderboard[], UHC: Leaderboard[], WALLS: Leaderboard[], PROTOTYPE: Leaderboard[], PAINTBALL: Leaderboard[], SKYWARS: Leaderboard[], MURDER_MYSTERY: Leaderboard[], SMASH_HEROES: Leaderboard[], DUELS: Leaderboard[], SPEED_UHC: Leaderboard[], TNTGAMES: Leaderboard[], BEDWARS: Leaderboard[], TURBO_KART_RACERS: Leaderboard[], BUILD_BATTLE: Leaderboard[], ARCADE: Leaderboard[], SKYCLASH: Leaderboard[], QUAKECRAFT: Leaderboard[], CRAZY_WALLS: Leaderboard[], MEGA_WALLS: Leaderboard[], VAMPIREZ: Leaderboard[] }>;
         /**
+         * @description Allows you to get recent games of a player
+         */
+        public getRecentGames(options?: methodOptions): Promise<RecentGame[]>;
+        /**
          * @description Allows you to clear cache
          */
-        public get sweepCache(): void;
+         public get sweepCache(): void;
         public get cache(): Map<string, object>;
     }
     export class Player {
@@ -117,8 +121,12 @@ declare module 'hypixel-api-reborn' {
         public history: string[];
         public rank: PLAYER_RANK;
         public mcVersion: string;
-        public lastLogin: number;
-        public firstLogin: number;
+        public lastLoginTimestamp: number;
+        public lastLogin: Date;
+        public lastLogoutTimestamp: number;
+        public lastLogout: Date;
+        public firstLoginTimestamp: number;
+        public firstLogin: Date;
         public recentlyPlayedGame: Game;
         public plusColor?: Color;
         public karma: number;
@@ -147,6 +155,7 @@ declare module 'hypixel-api-reborn' {
             blitzsg?: BlitzSurvivalGames,
             arena?: ArenaBrawl
         }
+        public getRecentGames(): Promise<RecentGame[]>;
     }
     export class Leaderboard {
         constructor(data: object);
@@ -343,7 +352,8 @@ declare module 'hypixel-api-reborn' {
         public description: string;
         public experience: number;
         public level: number;
-        public createdAt: number;
+        public createdAtTimestamp: number;
+        public createdAt: Date;
         public joinable: boolean;
         public publiclyListed: boolean;
         public tag: string;
@@ -355,7 +365,8 @@ declare module 'hypixel-api-reborn' {
             experienceKings: number,
             onlinePlayers: number
         };
-        public chatMuteUntil: number;
+        public chatMuteUntilTimestamp: number;
+        public chatMuteUntil: Date;
         public banner: { Base: string, Patterns: [{ Pattern: string, Color: string }] }
         public preferredGames: Game[];
         public members: GuildMember[];
@@ -369,8 +380,10 @@ declare module 'hypixel-api-reborn' {
         public auctionId: string;
         public auctioneerUuid: string;
         public coop: string[];
-        public auctionStart: number;
-        public auctionEnd: number;
+        public auctionStartTimestamp: number;
+        public auctionEndTimestamp: number;
+        public auctionStart: Date;
+        public auctionEnd: Date;
         public item: string;
         public itemLore: string;
         public startingBid: number;
@@ -386,6 +399,7 @@ declare module 'hypixel-api-reborn' {
         public profileId: string;
         public amount: number;
         public timestamp: number;
+        public at: Date;
         public bidder: string;
     }
     export class Product {
@@ -422,11 +436,13 @@ declare module 'hypixel-api-reborn' {
     export class GuildMember {
         constructor(data: object);
         public uuid: string;
-        public joinedAt: number;
+        public joinedAtTimestamp: number;
+        public joinedAt: Date;
         public questParticipation: number;
         public rank: string;
         public weeklyExperience: number;
-        public mutedUntil: number;
+        public mutedUntilTimestamp: number;
+        public mutedUntil: Date;
         public expHistory: { day: string, exp: number }[];
     }
     export class GuildRank {
@@ -434,14 +450,16 @@ declare module 'hypixel-api-reborn' {
         public name: string;
         public default: boolean;
         public tag: string | null;
-        public createdAt: number;
+        public createdAtTimestamp: number;
+        public createdAt: Date;
         public priority: number;
     }
     export class Friend {
         constructor(data: object);
         public sender: string;
         public receiver: string;
-        public friendSince: number;
+        public friendSinceTimestamp: number;
+        public friendSince: Date;
     }
     export class Booster {
         constructor(data: object);
@@ -464,6 +482,9 @@ declare module 'hypixel-api-reborn' {
         public firstJoin: number;
         public lastSave: number;
         public lastDeath: number;
+        public firstJoinAt: Date;
+        public lastSaveAt: Date;
+        public lastDeathAt: Date;
         public fairySouls: number;
         public skills: {
             taming: {
@@ -1197,6 +1218,15 @@ declare module 'hypixel-api-reborn' {
             pro: number,
             gtb: number
         };
+    }
+    export class RecentGame {
+        constructor(data: object)
+        public date: number;
+        public at: Date;
+        public mode: string;
+        public map: string;
+        public endedAt: Date;
+        public endedTimestamp: number;
     }
     export class MegaWalls {
         constructor(data: object)


### PR DESCRIPTION
addition of recent games, accessible via Client.getRecentGames() or <Player>.getRecentGames()
added timestamp ( breaking change )

**Please describe changes**

BREAKING CHANGE - A lot of properties returning timestamp now doesn't exist or returns timestamps.
naming scheme : 
original name => new name ( date ) | new name ( timestamp )
firstJoin => firstJoinAt | firstJoin
mutedUntil => mutedUntil | mutedUntilTimestamp
timestamp => at | timestamp
createdAt => createdAt | createdAtTimestamp

if the property name is the same, new Date( _bla.createdAt_ ) can still work ( you can parse a date twice )

*Description*

- [x] I've added new features. (methods or parameters)
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)