### PR TITLE
include Player in SkyblockMember

### DIFF
--- a/src/API/getRecentGames.js
+++ b/src/API/getRecentGames.js
@@ -10,7 +10,7 @@ module.exports = async function (query, playerData) {
   const res = await this._makeRequest(`/recentgames?uuid=${query}`);
   if (res.games === []) {
     if (!playerData) throw new Error(Errors.PLAYER_IS_INACTIVE);
-    if (new Date().getTime() - playerData.lastLogoutTimestamp < day3) throw new Error(Errors.PLAYER_DISABLED_ENDPOINT);
+    if (Date.now() - playerData.lastLogoutTimestamp < day3) throw new Error(Errors.PLAYER_DISABLED_ENDPOINT);
     throw new Error(Errors.PLAYER_IS_INACTIVE);
   }
   return res.games.map(x => new RecentGame(x));

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -38,6 +38,7 @@ class Player {
     }
     this.guild = data.guild ? data.guild : null;
     this.karma = data.karma || 0;
+    this.achievements = data.achievements;
     this.achievementPoints = data.achievementPoints || 0;
     this.totalExperience = data.networkExp || 0;
     this.level = getPlayerLevel(this.totalExperience) || 0;

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -7,7 +7,7 @@ const objectPath = require('object-path');
 class SkyblockMember {
   constructor (data) {
     this.uuid = data.uuid;
-    this.ign = data.m.ign || null;
+    this.player = data.m.player;
     this.profileName = data.profileName;
     this.gameMode = data.gameMode;
     this.firstJoinTimestamp = data.m.first_join;
@@ -96,9 +96,9 @@ class SkyblockMember {
 function getSkills (data) {
   const skillsObject = {};
   if (!objectPath.has(data, 'experience_skill_foraging')) {
-    if (data.achievements) {
+    if (data.player) {
       for (const [skill, achievement] of Object.entries(skills_achievements)) {
-        skillsObject[skill] = getLevelByAchievement(data.achievements[achievement], skill);
+        skillsObject[skill] = getLevelByAchievement(data.player.achievements[achievement], skill);
       }
       skillsObject.usedAchievementApi = true;
       return skillsObject;
@@ -106,9 +106,9 @@ function getSkills (data) {
     return null;
   }
   for (const skill of skills) {
-    skillsObject[skill] = getLevelByXp(data[`experience_skill_${skill}`], skill, data.achievements);
+    skillsObject[skill] = getLevelByXp(data[`experience_skill_${skill}`], skill, data.player ? data.player.achievements : undefined);
   }
-  if (data.achievements) skillsObject.usedAchievementApi = false;
+  if (data.player) skillsObject.usedAchievementApi = false;
   return skillsObject;
 }
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,7 +20,7 @@ interface playerMethodOptions extends methodOptions {
     guild?: boolean;
 }
 interface skyblockMemberOptions extends methodOptions {
-    includePlayerApi?: boolean;
+    includePlayer?: boolean;
 }
 declare module 'hypixel-api-reborn' {
     export const version: string;
@@ -138,6 +138,7 @@ declare module 'hypixel-api-reborn' {
         public recentlyPlayedGame: Game;
         public plusColor?: Color;
         public karma: number;
+        public achievements: object;
         public achievementPoints: number;
         public totalExperience: number;
         public level: number;
@@ -490,7 +491,7 @@ declare module 'hypixel-api-reborn' {
     export class SkyblockMember {
         constructor(data: object);
         public uuid: string;
-        public ign?: string;
+        public player?: Player;
         public profileName: string;
         public gameMode?: string;
         public firstJoin: number;


### PR DESCRIPTION
**Please describe changes**
Revamped the player API call in `getSkyblockProfiles` and `getSkyblockMember` which was originally intended for level 60 skills to simply include the whole Player class in SkyblockMember if the method option `includePlayer` is true. This way `nickname` and all other player properties are accessable via `<SkyblockMember>.player`.
Additionally had to include achievement data from the API into the Player class for this to work.

- [x] I've added new features. (methods or parameters)
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)