### PR TITLE
use Guild class in Player instead of raw API data

### DIFF
--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -9,11 +9,12 @@ module.exports = async function (query, options = { guild: false }) {
   const res = await this._makeRequest(`/player?uuid=${query}`);
 
   if (options.guild) {
+    const Guild = require('../structures/Guild/Guild');
     const guildRes = await this._makeRequest(`/guild?player=${query}`);
     if (!guildRes.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, guildRes.cause));
     }
-    res.player.guild = guildRes.guild;
+    res.player.guild = new Guild(guildRes.guild);
   }
   return new Player(res.player, this);
 };

--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -14,7 +14,7 @@ module.exports = async function (query, options = { guild: false }) {
     if (!guildRes.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, guildRes.cause));
     }
-    res.player.guild = new Guild(guildRes.guild);
+    res.player.guild = guildRes.guild ? new Guild(guildRes.guild) : null;
   }
   return new Player(res.player, this);
 };


### PR DESCRIPTION
**Please describe changes**
fetching a player with `guild` option set to true currently includes the raw API data instead of the Guild class contrary to the typings

- [x] I've added new features. (methods or parameters)
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)