### PR TITLE
fixed typo in getSkyblockMember

### DIFF
--- a/src/API/skyblock/getSkyblockMember.js
+++ b/src/API/skyblock/getSkyblockMember.js
@@ -26,7 +26,7 @@ module.exports = async function (query, options = { includePlayer: false }) {
     memberByProfileName.set(profile.cute_name, new SkyblockMember({
       uuid: query,
       profileName: profile.cute_name,
-      gameMode: profile.gameMode || null,
+      gameMode: profile.game_mode || null,
       m: profile.members[query]
     }));
   }


### PR DESCRIPTION
**Please describe changes**
fixed getSkyblockMember to use the spelling from the hypixel API

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)