### PR TITLE
fix SkyblockMember#lastDeathAt

### DIFF
--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -1,5 +1,6 @@
+/* eslint-disable camelcase */
 const { decode, getLevelByXp, getLevelByAchievement, getSlayerLevel } = require('../../utils/SkyblockUtils');
-const { skills, skills_achievements, pet_score } = require('../../utils/Constants'); // eslint-disable-line camelcase
+const { skyblock_year_0, skills, skills_achievements, pet_score } = require('../../utils/Constants');
 const Armor = require('./SkyblockArmor');
 const Item = require('./SkyblockItem');
 const objectPath = require('object-path');
@@ -14,7 +15,7 @@ class SkyblockMember {
     this.firstJoinAt = new Date(data.m.first_join);
     this.lastSave = data.m.last_save;
     this.lastSaveAt = new Date(data.m.last_save);
-    this.lastDeathAt = new Date(data.m.last_death);
+    this.lastDeathAt = new Date(skyblock_year_0 + data.m.last_death * 1000);
     this.lastDeath = data.m.last_death;
     this.getArmor = async () => {
       const base64 = data.m.inv_armor;

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -1,4 +1,6 @@
 module.exports = {
+  skyblock_year_0: 1560275700000,
+
   leveling_xp: {
     1: 50,
     2: 125,


### PR DESCRIPTION
**Please describe changes**
apparently the hypixel API uses timestamps relative to the skyblock year 0 for this property

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)