### PR TITLE
async Player fetching in getSkyblockProfiles

### DIFF
--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -1,5 +1,6 @@
 const Errors = require('../Errors');
 const toUuid = require('../utils/toUuid');
+const getGuild = require('./getGuild');
 module.exports = async function (query, options = { guild: false }) {
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
   const Player = require('../structures/Player');
@@ -8,13 +9,6 @@ module.exports = async function (query, options = { guild: false }) {
 
   const res = await this._makeRequest(`/player?uuid=${query}`);
 
-  if (options.guild) {
-    const Guild = require('../structures/Guild/Guild');
-    const guildRes = await this._makeRequest(`/guild?player=${query}`);
-    if (!guildRes.success) {
-      throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, guildRes.cause));
-    }
-    res.player.guild = guildRes.guild ? new Guild(guildRes.guild) : null;
-  }
+  res.player.guild = options.guild ? await getGuild.call(this, 'player', query) : null;
   return new Player(res.player, this);
 };

--- a/src/API/skyblock/getSkyblockAuctions.js
+++ b/src/API/skyblock/getSkyblockAuctions.js
@@ -6,7 +6,7 @@ module.exports = async function (page) {
     let currentPage = 0;
     let totalPages = 0;
     do {
-      const pageByNumber = await this._makeRequest(`/skyblock/auctions?page=${currentPage}`);
+      const pageByNumber = await this._makeRequest(`/skyblock/auctions?page=${currentPage}`, false);
       if (!pageByNumber.success) break;
       pageByNumber.auctions.forEach(auction => {
         auctions.push(new Auction(auction));
@@ -16,7 +16,7 @@ module.exports = async function (page) {
     } while (currentPage <= totalPages);
   } else {
     page = Math.floor(page);
-    const pageBySpecifiedPage = await this._makeRequest(`/skyblock/auctions?page=${page}`);
+    const pageBySpecifiedPage = await this._makeRequest(`/skyblock/auctions?page=${page}`, false);
     if (!pageBySpecifiedPage.success) return [];
     pageBySpecifiedPage.auctions.forEach(auction => {
       auctions.push(new Auction(auction));

--- a/src/API/skyblock/getSkyblockMember.js
+++ b/src/API/skyblock/getSkyblockMember.js
@@ -1,5 +1,6 @@
 const Errors = require('../../Errors');
 const toUuid = require('../../utils/toUuid');
+const getPlayer = require('../getPlayer');
 module.exports = async function (query, options = { fetchPlayer: false }) {
   const SkyblockMember = require('../../structures/SkyBlock/SkyblockMember');
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
@@ -10,19 +11,10 @@ module.exports = async function (query, options = { fetchPlayer: false }) {
     return new Map();
   }
 
-  let player;
-  if (options.fetchPlayer) {
-    const playerRes = await this._makeRequest(`/player?uuid=${query}`);
-    if (!playerRes.success) {
-      throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, playerRes.cause));
-    }
-    const Player = require('../../structures/Player');
-    player = new Player(playerRes.player, this);
-  }
-
+  const player = options.fetchPlayer ? await getPlayer.call(this, query, options) : null;
   const memberByProfileName = new Map();
   for (const profile of res.profiles) {
-    profile.members[query].player = player || null;
+    profile.members[query].player = player;
     memberByProfileName.set(profile.cute_name, new SkyblockMember({
       uuid: query,
       profileName: profile.cute_name,

--- a/src/API/skyblock/getSkyblockMember.js
+++ b/src/API/skyblock/getSkyblockMember.js
@@ -1,6 +1,6 @@
 const Errors = require('../../Errors');
 const toUuid = require('../../utils/toUuid');
-module.exports = async function (query, options = { includePlayer: false }) {
+module.exports = async function (query, options = { fetchPlayer: false }) {
   const SkyblockMember = require('../../structures/SkyBlock/SkyblockMember');
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
   query = await toUuid(query);
@@ -11,7 +11,7 @@ module.exports = async function (query, options = { includePlayer: false }) {
   }
 
   let player;
-  if (options.includePlayer) {
+  if (options.fetchPlayer) {
     const playerRes = await this._makeRequest(`/player?uuid=${query}`);
     if (!playerRes.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, playerRes.cause));

--- a/src/API/skyblock/getSkyblockProfiles.js
+++ b/src/API/skyblock/getSkyblockProfiles.js
@@ -13,14 +13,14 @@ module.exports = async function (query, options = { includePlayer: false }) {
   const players = new Map();
   if (options.includePlayer) {
     const Player = require('../../structures/Player');
-    const uniqueUuids = new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()));
-    for (const uuid of uniqueUuids) {
+    const uniqueUuids = [...new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()))];
+    await Promise.all(uniqueUuids.map(async uuid => {
       const playerRes = await this._makeRequest(`/player?uuid=${uuid}`);
       if (!playerRes.success) {
         throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, playerRes.cause));
       }
       players.set(uuid, new Player(playerRes.player, this));
-    }
+    }));
   }
 
   const profiles = [];

--- a/src/API/skyblock/getSkyblockProfiles.js
+++ b/src/API/skyblock/getSkyblockProfiles.js
@@ -1,5 +1,6 @@
 const Errors = require('../../Errors');
 const toUuid = require('../../utils/toUuid');
+const getPlayer = require('../getPlayer');
 module.exports = async function (query, options = { fetchPlayer: false }) {
   const SkyblockProfile = require('../../structures/SkyBlock/SkyblockProfile');
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
@@ -12,21 +13,19 @@ module.exports = async function (query, options = { fetchPlayer: false }) {
 
   const players = new Map();
   if (options.fetchPlayer) {
-    const Player = require('../../structures/Player');
     const uniqueUuids = [...new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()))];
     await Promise.all(uniqueUuids.map(async uuid => {
-      const playerRes = await this._makeRequest(`/player?uuid=${uuid}`);
-      if (!playerRes.success) {
-        throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, playerRes.cause));
-      }
-      players.set(uuid, new Player(playerRes.player, this));
+      const player = await getPlayer.call(this, uuid, options);
+      players.set(uuid, player);
     }));
   }
 
   const profiles = [];
   for (let i = 0; i < res.profiles.length; i++) {
-    for (const memberUuid of Object.keys(res.profiles[i].members)) {
-      res.profiles[i].members[memberUuid].player = players.get(memberUuid) || null;
+    if (options.fetchPlayer) {
+      for (const memberUuid of Object.keys(res.profiles[i].members)) {
+        res.profiles[i].members[memberUuid].player = players.get(memberUuid);
+      }
     }
 
     profiles.push({

--- a/src/API/skyblock/getSkyblockProfiles.js
+++ b/src/API/skyblock/getSkyblockProfiles.js
@@ -13,8 +13,8 @@ module.exports = async function (query, options = { includePlayer: false }) {
   const players = new Map();
   if (options.includePlayer) {
     const Player = require('../../structures/Player');
-    const uniqueUuidsArray = [...new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()))];
-    for (const uuid of uniqueUuidsArray) {
+    const uniqueUuids = new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()));
+    for (const uuid of uniqueUuids) {
       const playerRes = await this._makeRequest(`/player?uuid=${uuid}`);
       if (!playerRes.success) {
         throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, playerRes.cause));

--- a/src/API/skyblock/getSkyblockProfiles.js
+++ b/src/API/skyblock/getSkyblockProfiles.js
@@ -31,7 +31,6 @@ module.exports = async function (query, options = { fetchPlayer: false }) {
     profiles.push({
       profile_id: res.profiles[i].profile_id,
       profile_name: res.profiles[i].cute_name,
-      game_mode: res.profiles[i].game_mode,
       members: res.profiles[i].members,
       me: query
     });

--- a/src/API/skyblock/getSkyblockProfiles.js
+++ b/src/API/skyblock/getSkyblockProfiles.js
@@ -1,6 +1,6 @@
 const Errors = require('../../Errors');
 const toUuid = require('../../utils/toUuid');
-module.exports = async function (query, options = { includePlayer: false }) {
+module.exports = async function (query, options = { fetchPlayer: false }) {
   const SkyblockProfile = require('../../structures/SkyBlock/SkyblockProfile');
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
   query = await toUuid(query);
@@ -11,7 +11,7 @@ module.exports = async function (query, options = { includePlayer: false }) {
   }
 
   const players = new Map();
-  if (options.includePlayer) {
+  if (options.fetchPlayer) {
     const Player = require('../../structures/Player');
     const uniqueUuids = [...new Set((res.profiles.map(profile => Object.keys(profile.members)).flat()))];
     await Promise.all(uniqueUuids.map(async uuid => {

--- a/src/Client.js
+++ b/src/Client.js
@@ -18,7 +18,7 @@ class Client {
   async _makeRequest (options, url, useRateLimitManager = true) {
     if (!url) return;
     if (url !== '/key' && !options.noCacheCheck && requests.cache.has(url)) return requests.cache.get(url);
-    if (useRateLimitManager) await rateLimit.rateLimitManager();
+    if (useRateLimitManager) await rateLimit.rateLimitManager(this.options);
     return requests.request.call(this, url, options);
   }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -17,11 +17,8 @@ class Client {
 
   async _makeRequest (options, url, useRateLimitManager = true) {
     if (!url) return;
-    if (url !== '/key' && !options.noCacheCheck) {
-      if (requests.cache.has(url)) return requests.cache.get(url);
-      if (useRateLimitManager) await rateLimit.rateLimitManager();
-    }
-
+    if (url !== '/key' && !options.noCacheCheck && requests.cache.has(url)) return requests.cache.get(url);
+    if (useRateLimitManager) await rateLimit.rateLimitManager();
     return requests.request.call(this, url, options);
   }
 

--- a/src/Client.js
+++ b/src/Client.js
@@ -19,7 +19,7 @@ class Client {
     if (!url) return;
     if (url !== '/key' && !options.noCacheCheck) {
       if (requests.cache.has(url)) return requests.cache.get(url);
-      if (useRateLimitManager) rateLimit.rateLimitManager();
+      if (useRateLimitManager) await rateLimit.rateLimitManager();
     }
 
     return requests.request.call(this, url, options);

--- a/src/Client.js
+++ b/src/Client.js
@@ -15,11 +15,11 @@ class Client {
     rateLimit.init(this.getKeyInfo(), this.options.rateLimit);
   }
 
-  async _makeRequest (options, url) {
+  async _makeRequest (options, url, useRateLimitManager = true) {
     if (!url) return;
     if (url !== '/key' && !options.noCacheCheck) {
       if (requests.cache.has(url)) return requests.cache.get(url);
-      rateLimit.rateLimitManager();
+      if (useRateLimitManager) rateLimit.rateLimitManager();
     }
 
     return requests.request.call(this, url, options);

--- a/src/Private/rateLimit.js
+++ b/src/Private/rateLimit.js
@@ -6,11 +6,11 @@ module.exports = class RateLimit {
     setInterval(() => this.requests = 0, 1000 * 60);
   }
 
-  async rateLimitManager () {
+  async rateLimitManager (options) {
     this.requests++;
     // eslint-disable-next-line no-useless-return
-    if (this.options.rateLimit === 'NONE') return;
-    if (this.options.rateLimit === 'AUTO' && this.requests <= 60) return false;
+    if (options.rateLimit === 'NONE') return;
+    if (options.rateLimit === 'AUTO' && this.requests <= 60) return false;
     // eslint-disable-next-line no-return-assign
     if (Date.now() - this.lastRequestAt >= 500) return this.lastRequestAt = Date.now();
     // Wait before send, because user is on HARD RateLimit mode or AUTO, but passed 60 requests/min

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -8,7 +8,7 @@ const objectPath = require('object-path');
 class SkyblockMember {
   constructor (data) {
     this.uuid = data.uuid;
-    this.player = data.m.player;
+    this.player = data.m.player || null;
     this.profileName = data.profileName;
     this.gameMode = data.gameMode;
     this.firstJoinTimestamp = data.m.first_join;

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -10,7 +10,6 @@ class SkyblockMember {
     this.uuid = data.uuid;
     this.player = data.m.player || null;
     this.profileName = data.profileName;
-    this.gameMode = data.gameMode;
     this.firstJoinTimestamp = data.m.first_join;
     this.firstJoinAt = new Date(data.m.first_join);
     this.lastSave = data.m.last_save;

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -129,7 +129,8 @@ module.exports = {
     enchanting: 50,
     alchemy: 50,
     carpentry: 50,
-    runecrafting: 25
+    runecrafting: 25,
+    dungeons: 50
   },
 
   dungeon_xp: {

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -68,7 +68,7 @@ module.exports = {
 
     const xpCurrent = Math.floor(xp - xpTotal);
 
-    if (level < constants.skills_cap[type]) xpForNext = Math.ceil(xpTable[level + 1]);
+    if (type in constants.skills_cap ? level < constants.skills_cap[type] : level < maxLevelCap) xpForNext = Math.ceil(xpTable[level + 1]);
 
     const progress = Math.floor((Math.max(0, Math.min(xpCurrent / xpForNext, 1))) * 100);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,7 +20,7 @@ interface playerMethodOptions extends methodOptions {
     guild?: boolean;
 }
 interface skyblockMemberOptions extends methodOptions {
-    includePlayer?: boolean;
+    fetchPlayer?: boolean;
 }
 declare module 'hypixel-api-reborn' {
     export const version: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -484,7 +484,6 @@ declare module 'hypixel-api-reborn' {
         constructor(data: object);
         public profileId: string;
         public profileName: string;
-        public gameMode?: string;
         public members: SkyblockMember[];
         public me: SkyblockMember;
     }
@@ -493,7 +492,6 @@ declare module 'hypixel-api-reborn' {
         public uuid: string;
         public player?: Player;
         public profileName: string;
-        public gameMode?: string;
         public firstJoin: number;
         public lastSave: number;
         public lastDeath: number;


### PR DESCRIPTION
**Please describe changes**
 - Switched from `for of` to `Promise.all(map())`. Depending on the total amount of members this takes between half and a quarter of the time when I tested it.
 - added dungeons skill cap
 - renamed `includePlayer` to `fetchPlayer` to  emphasize the additional API request(s) (this is the final name for the next release, we should think about renaming the other fetchOption, `guild` to `fetchGuild` aswell)
 - removed the local API getters in `getSkyblockMember`, `getSkyblockProfiles` and `getPlayer` in favor of the already existing ones
 - exclude requests to /skyblock/auctions from the rate limit as hypixel does the same
 - fix rateLimitManager to be properly awaited

- [x] I've added new features. (methods or parameters)
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)