### PR TITLE
Fix achievement data in getLevelByXp

### DIFF
--- a/src/Private/rateLimit.js
+++ b/src/Private/rateLimit.js
@@ -2,25 +2,21 @@ const Errors = require('../Errors');
 module.exports = class RateLimit {
   rateLimitMonitor () {
     this.requests = 0;
-    // eslint-disable-next-line no-return-assign
-    setInterval(() => this.requests = 0, 1000 * 60);
+    setInterval(() => { this.requests = 0; }, 1000 * 60);
   }
 
   async rateLimitManager (options) {
     this.requests++;
-    // eslint-disable-next-line no-useless-return
     if (options.rateLimit === 'NONE') return;
-    if (options.rateLimit === 'AUTO' && this.requests <= 60) return false;
+    if (options.rateLimit === 'AUTO' && this.requests <= 60) return;
     // eslint-disable-next-line no-return-assign
     if (Date.now() - this.lastRequestAt >= 500) return this.lastRequestAt = Date.now();
     // Wait before send, because user is on HARD RateLimit mode or AUTO, but passed 60 requests/min
     this.waitingRequests++;
     // With rate limit set to HARD, you will never be able to pass the Ratelimit set by hypixel API if this is the only script you are using the API key with.
-    // eslint-disable-next-line promise/param-names
     await new Promise(r => setTimeout(r, 500 * this.waitingRequests), true);
     this.waitingRequests--;
     this.lastRequestAt = Date.now();
-    return true;
   }
 
   init (keyInfo, rateLimit) {

--- a/src/Private/requests.js
+++ b/src/Private/requests.js
@@ -15,9 +15,9 @@ module.exports = class Requests {
     if (!parsedRes.success) {
       throw new Error(Errors.SOMETHING_WENT_WRONG.replace(/{cause}/, res.cause));
     }
-    if (options.nocache) return (url === '/key' ? [parsedRes, res.headers] : parsedRes);
+    if (options.noCaching) return (url === '/key' ? [parsedRes, res.headers] : parsedRes);
     // split by question mark : first part is /path, remove /
-    if (!options.noCaching && this.options.cache && this.options.cacheFilter(url.split('?')[0].slice(1))) {
+    if (this.options.cache && this.options.cacheFilter(url.split('?')[0].slice(1))) {
       if (this.options.cacheSize < cached.size) cached.delete(cached.keys().next().value); // Map and its special "iterators"
       cached.set(url, parsedRes);
       if (this.options.cacheTime >= 0) setTimeout(() => cached.delete(url), 1000 * this.options.cacheTime);

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -109,14 +109,14 @@ module.exports = {
   ],
 
   skills_achievements: {
-    farming: 'skyblock_harvester',
-    mining: 'skyblock_excavator',
-    combat: 'skyblock_combat',
-    foraging: 'skyblock_gatherer',
-    fishing: 'skyblock_angler',
-    enchanting: 'skyblock_augmentation',
-    alchemy: 'skyblock_concoctor',
-    taming: 'skyblock_domesticator'
+    farming: 'skyblockHarvester',
+    mining: 'skyblockExcavator',
+    combat: 'skyblockCombat',
+    foraging: 'skyblockGatherer',
+    fishing: 'skyblockAngler',
+    enchanting: 'skyblockAugmentation',
+    alchemy: 'skyblockConcoctor',
+    taming: 'skyblockDomesticator'
   },
 
   skills_cap: {

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -33,18 +33,18 @@ module.exports = {
     let maxLevel = Math.max(...Object.keys(xpTable));
     let maxLevelCap = maxLevel;
 
-    if (achievements && constants.skills_cap[type] > maxLevel && type in constants.skills_achievements) {
+    if (constants.skills_cap[type] > maxLevel) {
       xpTable = Object.assign(constants.xp_past_50, xpTable);
 
       maxLevel = Math.max(...Object.keys(xpTable));
-      maxLevelCap = Math.max(maxLevelCap, achievements[constants.skills_achievements[type]]);
+      if (achievements && type in constants.skills_achievements) maxLevelCap = achievements[constants.skills_achievements[type]];
     }
 
     if (isNaN(xp)) {
       return {
         xp: 0,
         level: 0,
-        maxLevel: maxLevelCap,
+        maxLevel,
         xpCurrent: 0,
         xpForNext: xpTable[1],
         progress: 0
@@ -68,14 +68,14 @@ module.exports = {
 
     const xpCurrent = Math.floor(xp - xpTotal);
 
-    if (type in constants.skills_cap ? level < constants.skills_cap[type] : level < maxLevelCap) xpForNext = Math.ceil(xpTable[level + 1]);
+    if (level < maxLevel) xpForNext = Math.ceil(xpTable[level + 1]);
 
     const progress = Math.floor((Math.max(0, Math.min(xpCurrent / xpForNext, 1))) * 100);
 
     return {
       xp,
       level,
-      maxLevel: maxLevelCap,
+      maxLevel,
       xpCurrent,
       xpForNext,
       progress
@@ -85,20 +85,18 @@ module.exports = {
   getLevelByAchievement (achievementLevel, type) {
     let xpTable = constants.leveling_xp;
     let maxLevel = Math.max(...Object.keys(xpTable));
-    let maxLevelCap = maxLevel;
 
     if (constants.skills_cap[type] > maxLevel && type in constants.skills_achievements) {
       xpTable = Object.assign(constants.xp_past_50, xpTable);
 
       maxLevel = Math.max(...Object.keys(xpTable));
-      maxLevelCap = Math.max(maxLevelCap, achievementLevel);
     }
 
     if (isNaN(achievementLevel)) {
       return {
         xp: 0,
         level: 0,
-        maxLevel: maxLevelCap,
+        maxLevel,
         xpCurrent: 0,
         xpForNext: xpTable[1],
         progress: 0
@@ -108,16 +106,16 @@ module.exports = {
     let xpTotal = 0;
     let xpForNext = 0;
 
-    for (let x = 1; x <= maxLevelCap; x++) {
+    for (let x = 1; x <= achievementLevel; x++) {
       xpTotal += xpTable[x];
     }
 
-    if (achievementLevel < maxLevelCap) xpForNext = Math.ceil(xpTable[achievementLevel + 1]);
+    if (achievementLevel < maxLevel) xpForNext = Math.ceil(xpTable[achievementLevel + 1]);
 
     return {
       xp: xpTotal,
       level: achievementLevel,
-      maxLevel: maxLevelCap,
+      maxLevel,
       xpCurrent: 0,
       xpForNext,
       progress: 0


### PR DESCRIPTION
**Please describe changes**
 - fixed getting max level past 50 and level if skill API is disabled. Broken due to changes in `<Player>.achievements` from #44 
 - clean up some code in rateLimit

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed a bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)