### PR TITLE
+ Skyblock auctions rewrite & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.1.0",
+    "eslint-plugin-standard": "^5.0.0",
     "path": "^0.12.7",
     "tslint": "^6.1.3",
     "typescript": "^4.0.5"

--- a/src/API/skyblock/getEndedSkyblockAuctions.js
+++ b/src/API/skyblock/getEndedSkyblockAuctions.js
@@ -1,7 +1,7 @@
 const PartialAuction = require('../../structures/SkyBlock/Auctions/PartialAuction');
 const AuctionInfo = require('../../structures/SkyBlock/Auctions/AuctionInfo');
 module.exports = async function (includeItemBytes = false) {
-  const res = await this._makeRequest('/skyblock/auctions_ended');
+  const res = await this._makeRequest('/skyblock/auctions_ended', false);
   return {
     info: new AuctionInfo({ ...res, totalAuctions: res.auctions.length, totalPages: 1 }),
     auctions: res.auctions.length ? res.auctions.map(a => new PartialAuction(a, includeItemBytes)) : []

--- a/src/API/skyblock/getSkyblockAuctions.js
+++ b/src/API/skyblock/getSkyblockAuctions.js
@@ -30,7 +30,7 @@ module.exports = async function (range, options = {}) {
   if (!Array.isArray(range)) range = [parseInt(range), parseInt(range)].sort();
   if (isNaN(range[0])) throw new Error(Errors.PAGE_INDEX_ERROR);
   if (parseInt(options.retries) !== options.retries || options.retries > 10 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
-  if (parseInt(options.cooldown) !== options.cooldown || options.cooldown > 1000 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
+  if (parseInt(options.cooldown) !== options.cooldown || options.cooldown > 3000 || options.cooldown < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
   const result = { auctions: [] };
   const fetches = [];
   const failedPages = [];

--- a/src/API/skyblock/getSkyblockAuctions.js
+++ b/src/API/skyblock/getSkyblockAuctions.js
@@ -27,7 +27,7 @@ module.exports = async function (range, options = {}) {
   options.retries = options.retries || 3;
   options.cooldown = options.cooldown || 100;
   if (!range || range === '*') range = [0, (await getPage(0, { noAuctions: true })).info.totalPages];
-  if (!Array.isArray(range)) range = [parseInt(range), parseInt(range)];
+  if (!Array.isArray(range)) range = [parseInt(range), parseInt(range)].sort();
   if (isNaN(range[0])) throw new Error(Errors.PAGE_INDEX_ERROR);
   if (parseInt(options.retries) !== options.retries || options.retries > 10 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
   if (parseInt(options.cooldown) !== options.cooldown || options.cooldown > 1000 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);

--- a/src/API/skyblock/getSkyblockAuctions.js
+++ b/src/API/skyblock/getSkyblockAuctions.js
@@ -1,30 +1,62 @@
-module.exports = async function (page, includeItemBytes = false) {
-  const Auction = require('../../structures/SkyBlock/Auctions/Auction');
-  const AuctionInfo = require('../../structures/SkyBlock/Auctions/AuctionInfo');
-
-  const auctions = [];
-  let info;
-  if (page !== 0 && (!page || isNaN(page))) {
-    let currentPage = 0;
-    let totalPages = 0;
-    do {
-      const pageByNumber = await this._makeRequest(`/skyblock/auctions?page=${currentPage}`, false);
-      if (!pageByNumber.success) break;
-      pageByNumber.auctions.forEach(auction => {
-        auctions.push(new Auction(auction, includeItemBytes));
-      });
-      info = info || new AuctionInfo(pageByNumber);
-      currentPage++;
-      totalPages = pageByNumber.totalPages;
-    } while (currentPage <= totalPages);
-  } else {
-    page = Math.floor(page);
-    const pageBySpecifiedPage = await this._makeRequest(`/skyblock/auctions?page=${page}`, false);
-    if (!pageBySpecifiedPage.success) return [];
-    pageBySpecifiedPage.auctions.forEach(auction => {
-      auctions.push(new Auction(auction, includeItemBytes));
-    });
-    info = new AuctionInfo(pageBySpecifiedPage);
+const Auction = require('../../structures/SkyBlock/Auctions/Auction');
+const AuctionInfo = require('../../structures/SkyBlock/Auctions/AuctionInfo');
+const Errors = require('../../Errors');
+let _makeRequest;
+async function getPage (page = 0, options = {}) {
+  const content = await _makeRequest(`/skyblock/auctions?page=${page}`, false);
+  const result = {};
+  if (!options.noInfo) result.info = new AuctionInfo(content);
+  if (options.raw) result.auctions = content.auctions;
+  else if (options.noAuctions) result.auctions = [];
+  else result.auctions = content.auctions.map(x => new Auction(x, options.includeItemBytes));
+  return result;
+}
+async function noReject (promise, args = [], retries = 3, cooldown = 100) {
+  try {
+    const result = await promise.apply(null, args);
+    return result;
+  } catch (e) {
+    if (retries) {
+      await new Promise(resolve => setTimeout(resolve, cooldown));
+      return await noReject(promise, args, retries - 1, cooldown);
+    } else return null;
   }
-  return { info, auctions };
+}
+module.exports = async function (range, options = {}) {
+  _makeRequest = this._makeRequest;
+  options.retries = options.retries || 3;
+  options.cooldown = options.cooldown || 100;
+  if (!range || range === '*') range = [0, (await getPage(0, { noAuctions: true })).info.totalPages];
+  if (!Array.isArray(range)) range = [parseInt(range), parseInt(range)];
+  if (isNaN(range[0])) throw new Error(Errors.PAGE_INDEX_ERROR);
+  if (parseInt(options.retries) !== options.retries || options.retries > 10 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
+  if (parseInt(options.cooldown) !== options.cooldown || options.cooldown > 1000 || options.retries < 0) throw new Error(Errors.INVALID_OPTION_VALUE);
+  const result = { auctions: [] };
+  const fetches = [];
+  const failedPages = [];
+  if (options.noAuctions) return { info: options.noInfo ? null : (await getPage(range[1], { noAuctions: true })).info };
+  for (let i = range[0]; i <= range[1]; i++) {
+    if (options.race) {
+      fetches.push(noReject(getPage, [i, options], options.retries, options.cooldown));
+    } else {
+      const resp = await noReject(getPage, [i, options], options.retries, options.cooldown);
+      if (resp) {
+        result.auctions = result.auctions.concat(resp.auctions);
+        if (resp.info) result.info = resp.info;
+      } else failedPages.push(i);
+    }
+  }
+  if (fetches.length) {
+    result.auctions = (await Promise.all(fetches)).reduce((pV, cV, _, index) => {
+      if (!cV) {
+        failedPages.push(index + range[0]);
+        return pV;
+      };
+      if (cV.info) result.info = cV.info;
+      if (cV.auctions.length) return pV.concat(cV.auctions);
+      return pV;
+    }, []);
+  }
+  result.info = result.info ? result.info._extend('failedPages', failedPages) : { failedPages };
+  return result;
 };

--- a/src/Client.js
+++ b/src/Client.js
@@ -36,10 +36,10 @@ class Client {
 
   /**
    * Delete all cache entries
-   * @returns {void}
+   * @returns {Promise<void|boolean[]>}
    */
-  get sweepCache () {
-    return requests.sweepCache;
+  sweepCache (...args) {
+    return requests.sweepCache(...args);
   }
 }
 /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -38,7 +38,7 @@ class Client {
    * Delete all cache entries
    * @returns {void}
    */
-  sweepCache () {
+  get sweepCache () {
     return requests.sweepCache;
   }
 }

--- a/src/Client.js
+++ b/src/Client.js
@@ -36,10 +36,11 @@ class Client {
 
   /**
    * Delete all cache entries
+   * @param {?number} amount
    * @returns {Promise<void|boolean[]>}
    */
-  sweepCache (...args) {
-    return requests.sweepCache(...args);
+  sweepCache (amount) {
+    return requests.sweepCache(amount);
   }
 }
 /**

--- a/src/Errors.js
+++ b/src/Errors.js
@@ -21,6 +21,8 @@ module.exports = {
   INVALID_GUILD_SEARCH_PARAMETER: '[hypixel-api-reborn] getGuild() searchParameter must be \'id\', \'guild\' or \'player\'.',
   SOMETHING_WENT_WRONG: '[hypixel-api-reborn] Something went wrong. {cause}',
   GUILD_DOES_NOT_EXIST: '[hypixel-api-reborn] Guild does not exist.',
+  PAGE_INDEX_ERROR: '[hypixel-api-reborn] Invalid page index. Must be an integer, an array of 2 integers, or a keyword. For help join our Discord Server https://discord.gg/NSEBNMM',
+  INVALID_OPTION_VALUE: '[hypixel-api-reborn] Invalid option value! For help join our Discord Server https://discord.gg/NSEBNMM',
   INVALID_RESPONSE_BODY: '[hypixel-api-reborn] An error occurred while converting to JSON. Perhaps this is due to an update or maintenance. For help join our Discord Server https://discord.gg/NSEBNMM',
   INVALID_RATE_LIMIT_OPTION: '[hypixel-api-reborn] Rate Limit provided in Client options must be \'HARD\', \'AUTO\', or \'NONE\'. For help join our Discord Server https://discord.gg/NSEBNMM'
 };

--- a/src/Private/requests.js
+++ b/src/Private/requests.js
@@ -3,8 +3,8 @@ const BASE_URL = 'https://api.hypixel.net';
 const Errors = require('../Errors');
 const cached = new Map();
 module.exports = class Requests {
-  async request (url, options) {
-    const res = await fetch(BASE_URL + url + (/\?/.test(url) ? '&' : '?') + `key=${this.key}`);
+  async request (url, options = {}) {
+    const res = await fetch(BASE_URL + url + (/\?/.test(url) ? '&' : '?') + `key=${this.key}`, options);
     if (res.status === 522) throw new Error(Errors.ERROR_STATUSTEXT.replace(/{statustext}/, '522 Connection Timed Out'));
     const parsedRes = await res.json().catch(() => {
       throw new Error(Errors.INVALID_RESPONSE_BODY);

--- a/src/structures/MiniGames/SkyWars.js
+++ b/src/structures/MiniGames/SkyWars.js
@@ -240,13 +240,7 @@ class SkyWars {
  */
 /**
  * @typedef {Object} SkyWarsModeExtendedStats
- * @property {number} playedGames Played games
- * @property {number} kills Kills
- * @property {number} deaths Deaths
- * @property {number} wins Wins
- * @property {number} losses Losses
- * @property {number} KDRatio Kill Death ratio
- * @property {number} WLRatio Win Loss ratio
+ * @property {SkyWarsModeStats} total Total Stats
  * @property {SkyWarsModeStats} normal Normal Mode Stats
  * @property {SkyWarsModeStats} insane Insane Mode Stats
  */

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -143,6 +143,16 @@ class Player {
      */
     this.isOnline = this.lastLoginTimestamp > this.lastLogoutTimestamp;
     /**
+     * Last time player claimed the daily reward
+     * @type {Date | null}
+     */
+    this.lastDailyReward = new Date(data.lastAdsenseGenerateTime) || null;
+    /**
+     * Last time player claimed the daily reward, as timestamp
+     * @type {number | null}
+     */
+    this.lastDailyRewardTimestamp = data.lastAdsenseGenerateTime || null;
+    /**
      * Player recent games
      * @returns {Promise<Array<RecentGame>>}
      */

--- a/src/structures/SkyBlock/Auctions/Auction.js
+++ b/src/structures/SkyBlock/Auctions/Auction.js
@@ -18,17 +18,73 @@ class Auction extends BaseAuction {
      * @type {Date}
      */
     this.auctionStart = data.start ? new Date(data.start) : null;
+    /**
+     * Auction end timestamp as Date
+     * @type {Date}
+     */
     this.auctionEnd = data.end ? new Date(data.end) : null;
+    /**
+     * Auction end timestamp as timestamp
+     * @type {number}
+     */
     this.auctionEndTimestamp = data.end || null;
+    /**
+     * Auction Item Name
+     * @type {string}
+     */
     this.item = data.item_name || null;
+    /**
+     * Auction Item lore ( plain text )
+     * @type {string}
+     */
     this.itemLore = data.item_lore ? data.item_lore.replace(/§([1-9]|[a-l])|§/gm, '') : null;
+    /**
+     * Auctipn Item Lore as it is from the API
+     * @type {string}
+     */
     this.itemLoreRaw = data.item_lore || null;
+    /**
+     * Rarity of Item
+     * @type {Rarity}
+     */
     this.rarity = data.tier || null;
+    /**
+     * Auction starting bid, or price for BIN
+     * @type {number}
+     */
     this.startingBid = data.starting_bid || 0;
+    /**
+     * Auction's highest bid, if it is bidded
+     * @type {number}
+     */
     this.highestBid = data.highest_bid_amount || 0;
+    /**
+     * Auction bids
+     * @type {Bid[]}
+     */
     this.bids = data.bids.length ? data.bids.map(b => new Bid(b)) : [];
+    /**
+     * is Auction Claimed
+     * @type {boolean}
+     */
     this.claimed = data.claimed || false;
+    /**
+     * Which bidders, if any, claimed
+     * @type {string[]}
+     */
     this.claimedBidders = this.claimed ? data.claimed_bidders : [];
   }
 }
+/**
+ * @typedef {string} Rarity
+ * * `VERY_SPECIAL`
+ * * `SPECIAL`
+ * * `SUPREME`
+ * * `MYTHIC`
+ * * `LEGENDARY`
+ * * `EPIC`
+ * * `RARE`
+ * * `UNCOMMON`
+ * * `COMMON`
+ */
 module.exports = Auction;

--- a/src/structures/SkyBlock/Auctions/AuctionInfo.js
+++ b/src/structures/SkyBlock/Auctions/AuctionInfo.js
@@ -35,5 +35,10 @@ class AuctionInfo {
      */
     this.age = parseInt(data._headers.get('age')) || 0;
   }
+
+  _extend (name, value) {
+    this[name] = value;
+    return this;
+  }
 };
 module.exports = AuctionInfo;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,26 +22,45 @@ interface playerMethodOptions extends methodOptions {
 interface skyblockMemberOptions extends methodOptions {
     fetchPlayer?: boolean;
 }
+interface auctionsOptions {
+    noInfo?: boolean;
+    noAuctions?: boolean;
+    raw?: boolean;
+    retries?: number;
+    cooldown?: number;
+    race?: boolean;
+    includeItemBytes?: boolean
+}
 declare module 'hypixel-api-reborn' {
     export const version: string;
 
     export const Errors: {
+        CACHE_FILTER_INVALID: string,
+        CACHE_LIMIT_MUST_BE_A_NUMBER: string,
+        CACHE_TIME_MUST_BE_A_NUMBER: string,
+        ERROR_CODE_CAUSE: string,
+        ERROR_STATUSTEXT: string,
+        GUILD_DOES_NOT_EXIST: string,
         INVALID_API_KEY: string,
-        NO_API_KEY: string,
-        KEY_MUST_BE_A_STRING: string,
-        NO_NICKNAME_UUID: string,
-        NO_UUID: string,
-        MALFORMED_UUID: string,
-        PLAYER_DOES_NOT_EXIST: string,
-        PLAYER_HAS_NEVER_LOGGED: string,
-        NO_GUILD_QUERY: string,
         INVALID_GUILD_ID: string,
         INVALID_GUILD_SEARCH_PARAMETER: string,
-        GUILD_DOES_NOT_EXIST: string,
+        INVALID_OPTION_VALUE: string,
+        INVALID_RATE_LIMIT_OPTION: string,
         INVALID_RESPONSE_BODY: string,
+        KEY_MUST_BE_A_STRING: string,
+        MALFORMED_UUID: string,
+        NO_API_KEY: string,
+        NO_GUILD_QUERY: string,
+        NO_NICKNAME_UUID: string,
+        NO_UUID: string,
         OPTIONS_MUST_BE_AN_OBJECT: string,
-        CACHE_TIME_MUST_BE_A_NUMBER: string,
-        CACHE_LIMIT_MUST_BE_A_NUMBER: string
+        PAGE_INDEX_ERROR: string,
+        PLAYER_DISABLED_ENDPOINT: string,
+        PLAYER_DOES_NOT_EXIST: string,
+        PLAYER_HAS_NEVER_LOGGED: string,
+        PLAYER_IS_INACTIVE: string,
+        SOMETHING_WENT_WRONG: string,
+        UUID_NICKNAME_MUST_BE_A_STRING: string
     }
     export class Client {
         constructor(key: string, options?: clientOptions);
@@ -84,10 +103,10 @@ declare module 'hypixel-api-reborn' {
         public getSkyblockMember(query: string, options?: skyblockMemberOptions): Promise<Map<string, SkyblockMember>>;
         /**
          * @description Allows you to get all skyblock auctions
-         * @param page - number (optional)
-         * @param includeItemBytes - include item bytes (optional), only possible when fetching a single page
+         * @param page - "*", a page number, or an array with the start and the end page number ( automatically sorted )
+         * @param options Options
          */
-        public getSkyblockAuctions(page?: number, includeItemBytes?: boolean, options?: methodOptions): Promise<{info: AuctionInfo, auctions: Auction[]}>;
+        public getSkyblockAuctions(page?: ( '*' | number | [number,number] ), options?: auctionsOptions, options?: methodOptions): Promise<{info?: AuctionInfo, auctions?: Auction[]}>;
         /**
          * @description Allows you to get all ended auctions in around the last 60 seconds
          * @param includeItemBytes - include item bytes (optional)
@@ -438,7 +457,8 @@ declare module 'hypixel-api-reborn' {
         public lastUpdated: number;
         public totalPages: number;
         public page: number;
-        public totalAuctions: number
+        public totalAuctions: number;
+        public failedPages: number[]
     }
     export class Bid {
         constructor(data: object);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,7 @@ interface playerMethodOptions extends methodOptions {
 interface skyblockMemberOptions extends methodOptions {
     fetchPlayer?: boolean;
 }
-interface auctionsOptions {
+interface auctionsOptions extends methodOptions {
     noInfo?: boolean;
     noAuctions?: boolean;
     raw?: boolean;
@@ -106,7 +106,7 @@ declare module 'hypixel-api-reborn' {
          * @param page - "*", a page number, or an array with the start and the end page number ( automatically sorted )
          * @param options Options
          */
-        public getSkyblockAuctions(page?: ( '*' | number | [number,number] ), options?: auctionsOptions, options?: methodOptions): Promise<{info?: AuctionInfo, auctions?: Auction[]}>;
+        public getSkyblockAuctions(page?: ( '*' | number | [number,number] ), options?: auctionsOptions): Promise<{info?: AuctionInfo, auctions?: Auction[]}>;
         /**
          * @description Allows you to get all ended auctions in around the last 60 seconds
          * @param includeItemBytes - include item bytes (optional)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ interface clientOptions {
     cache?: boolean;
     cacheTime?: number;
     cacheSize?: number;
-    cacheFilter?: string | string[] | { 'whitelist':string | string[], 'blacklist':string | string[] };
+    cacheFilter?: string | string[] | { 'whitelist': string | string[], 'blacklist': string | string[] };
     rateLimit?: 'HARD' | 'AUTO' | 'NONE';
 }
 interface methodOptions {
@@ -106,12 +106,12 @@ declare module 'hypixel-api-reborn' {
          * @param page - "*", a page number, or an array with the start and the end page number ( automatically sorted )
          * @param options Options
          */
-        public getSkyblockAuctions(page?: ( '*' | number | [number,number] ), options?: auctionsOptions): Promise<{info?: AuctionInfo, auctions?: Auction[]}>;
+        public getSkyblockAuctions(page?: ('*' | number | [number, number]), options?: auctionsOptions): Promise<{ info?: AuctionInfo, auctions?: Auction[] }>;
         /**
          * @description Allows you to get all ended auctions in around the last 60 seconds
          * @param includeItemBytes - include item bytes (optional)
          */
-        public getEndedSkyblockAuctions(includeItemBytes?: boolean, options?: methodOptions): Promise<{info: AuctionInfo, auctions: Auction[]}>;
+        public getEndedSkyblockAuctions(includeItemBytes?: boolean, options?: methodOptions): Promise<{ info: AuctionInfo, auctions: Auction[] }>;
         /**
          * @description Allows you to get all auctions of player
          * @param query - player nickname or uuid
@@ -153,9 +153,10 @@ declare module 'hypixel-api-reborn' {
          */
         public getAPIStatus(): Promise<APIStatus>;
         /**
+         * @param amount - Amount of cache entries to delete
          * @description Allows you to clear cache
          */
-        public sweepCache(): void;
+        public sweepCache(amount?: number): void;
         public get cache(): Map<string, object>;
     }
     export class Player {
@@ -428,7 +429,7 @@ declare module 'hypixel-api-reborn' {
         public bin: boolean;
         public itemBytes: ItemBytes | null;
     }
-    export class Auction extends BaseAuction{
+    export class Auction extends BaseAuction {
         constructor(data: object);
         public coop: string[] | [];
         public auctionStartTimestamp: number;


### PR DESCRIPTION
**Please describe changes**
+ Skyblock Auctions rewrite : Now has way more options and can be faster by making simultaneous requests at once. Also included a retry and cooldown option.
+ It is backwards compatible, so it supports the old options... the fetch technique for every pages is by default the slower way, so might still want to update :) 
+ sweep cache is get ( it returns a function that isn't called )
+ Disabled rate limit for auctions_ended because you don't need a key either ( afaik )
+ added J s d o c
+ updated index.ts ( the errors class )

Should test it first & check jsdoc because I might've made some mistakes in jsdoc
*Description*

- [x] I've added new features. (methods or parameters)
- [x] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)