### PR TITLE
fix(Pet): check if data.petStats exists

### DIFF
--- a/src/structures/Pet.js
+++ b/src/structures/Pet.js
@@ -24,7 +24,7 @@ class Pet {
      * @type {boolean}
      */
     this.active = data.currentPet === name.toUpperCase();
-    const stats = data.petStats[name.toUpperCase()];
+    const stats = data.petStats && data.petStats[name.toUpperCase()];
     /**
      * Stats of the pet, if any
      * @type {object}


### PR DESCRIPTION
**Please describe changes**
apparently the hypixel API doesn't provide that information for all players and it can be undefined sometimes, resulting in `<Client>.getPlayer` to reject

*Description*

- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)