### PR TITLE
fix(SkyWars): shards

### DIFF
--- a/src/structures/MiniGames/SkyWars.js
+++ b/src/structures/MiniGames/SkyWars.js
@@ -137,7 +137,7 @@ class SkyWars {
      * Shards
      * @type {number}
      */
-    this.shards = data.shards || 0;
+    this.shards = data.shard || 0;
     /**
      * Shard By Mode
      * @type {SkyWarsShardsInMode}


### PR DESCRIPTION
**Please describe changes**
`Player`.stats.skywars.shards always returns 0 due to a typo
*Description*

- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)