### PR TITLE
fix(Client): jsdoc example for getPlayer

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -59,7 +59,7 @@ class Client {
    * })
    * @example
    * // Get player's guild along with player stats
-   * hypixel.getPlayer('Minikloon').then(player => {
+   * hypixel.getPlayer('Minikloon', { guild: true }).then(player => {
    *   console.log(player.guild) // null if player isn't is guild
    *   console.log(player.guild.name) // Mini Squid
    *   console.log(player.guild.level) // 110


### PR DESCRIPTION
**Please describe changes**
closes #134
the jsdoc example for `getPlayer` is missing `{ guild: true }` as fetch options, so when trying to recreate it `<Player>.guild` is always `null`

*Description*

- [ ] I've added new features. (methods or parameters)
- [x] I've added jsdoc and typings.
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)