### PR TITLE
fix <SkyblockMember>.firstJoinHubAt 

### DIFF
--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -48,7 +48,7 @@ class SkyblockMember {
      * Timestamp when player first joined the SkyBlock Hub as Date
      * @type {Date}
      */
-    this.firstJoinHubAt = new Date(skyblock_year_0 + data.m.first_join_hub);
+    this.firstJoinHubAt = new Date(this.firstJoinTimestamp + data.m.first_join_hub);
     /**
      * Last save timestamp
      * @type {number}

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -48,7 +48,7 @@ class SkyblockMember {
      * Timestamp when player first joined the SkyBlock Hub as Date
      * @type {Date}
      */
-    this.firstJoinHubAt = new Date(data.m.first_join_hub);
+    this.firstJoinHubAt = new Date(skyblock_year_0 + data.m.first_join_hub);
     /**
      * Last save timestamp
      * @type {number}


### PR DESCRIPTION
**Please describe changes**
data.m.first_join_hub is relative to the profile creation timestamp

*Description*

- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)