### PR TITLE
feat(rsw+guild.members.me): better rsw, and guild.members.me and more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",

--- a/src/API/getGuild.js
+++ b/src/API/getGuild.js
@@ -5,12 +5,13 @@ module.exports = async function (searchParameter, query) {
   if (!query) throw new Error(Errors.NO_GUILD_QUERY);
   const Guild = require('../structures/Guild/Guild');
   if (searchParameter === 'id' && !isGuildID(query)) throw new Error(Errors.INVALID_GUILD_ID);
-  if (searchParameter === 'player') query = await toUuid(query);
+  const isPlayerQuery = searchParameter === 'player';
+  if (isPlayerQuery) query = await toUuid(query);
   if (!['id', 'name', 'player'].includes(searchParameter)) throw new Error(Errors.INVALID_GUILD_SEARCH_PARAMETER);
   const res = await this._makeRequest(`/guild?${searchParameter}=${encodeURI(query)}`);
   if (!res.guild && searchParameter !== 'player') {
     throw new Error(Errors.GUILD_DOES_NOT_EXIST);
   }
 
-  return res.guild ? new Guild(res.guild) : null;
+  return res.guild ? new Guild(res.guild, isPlayerQuery ? query : null) : null;
 };

--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -1,18 +1,26 @@
 const Errors = require('../Errors');
 const toUuid = require('../utils/toUuid');
 const getGuild = require('./getGuild');
+const getRecentGames = require('./getRecentGames');
+const getRankedSkyWars = require('./getRankedSkyWars');
 module.exports = async function (query, options = { guild: false }) {
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
   const Player = require('../structures/Player');
   query = await toUuid(query);
   const res = await this._makeRequest(`/player?uuid=${query}`);
   if (query && !res.player) throw new Error(Errors.PLAYER_HAS_NEVER_LOGGED);
+  let guild = null;
+  let recentGames = null;
+  let rankedSW = null;
   if (options.guild) {
-    const guild = await getGuild.call(this, 'player', query);
-    if (guild) {
-      Object.assign(guild, { me: guild.members.find((m) => m.uuid === query) });
-    }
-    res.player.guild = guild;
+    guild = getGuild.call(this, 'player', query);
   }
-  return new Player(res.player, this);
+  if (options.recentGames) {
+    recentGames = getRecentGames.call(this, query);
+  }
+  if (options.currentRankedSW) {
+    rankedSW = getRankedSkyWars.call(this, query);
+  }
+  [guild, recentGames, rankedSW] = await Promise.all([guild, recentGames, rankedSW]);
+  return new Player(res.player, this, {guild, recentGames, rankedSW});
 };

--- a/src/API/getPlayer.js
+++ b/src/API/getPlayer.js
@@ -3,7 +3,7 @@ const toUuid = require('../utils/toUuid');
 const getGuild = require('./getGuild');
 const getRecentGames = require('./getRecentGames');
 const getRankedSkyWars = require('./getRankedSkyWars');
-module.exports = async function (query, options = { guild: false }) {
+module.exports = async function (query, options = { guild: false, recentGames: false, currentRankedSW: false }) {
   if (!query) throw new Error(Errors.NO_NICKNAME_UUID);
   const Player = require('../structures/Player');
   query = await toUuid(query);

--- a/src/Client.js
+++ b/src/Client.js
@@ -398,6 +398,8 @@ class Client extends EventEmitter {
  * @property {boolean} [noCacheCheck=false] Disable/Enable cache checking
  * @property {boolean} [noCaching=false] Disable/Enable writing to cache
  * @property {boolean} [guild=false] Disable/Enable request for player's guild
+ * @property {boolean} [recentGames=false] Disable/Enable request for player's recent game
+ * @property {boolean} [currentRankedSW=false] Disable/Enable request for player's current ranked SkyWars rating. Previous ratings will always show mindless of this option.
  * @prop {object} [headers={}] Extra Headers ( like User-Agent ) to add to request. Overrides the headers globally provided.
  */
 /**

--- a/src/structures/Guild/Guild.js
+++ b/src/structures/Guild/Guild.js
@@ -9,8 +9,9 @@ const {getGuildLevel, parseHistory} = require('../../utils/guildExp');
 class Guild {
   /**
    * @param {data} data Guild data
+   * @param {string} [me] Player uuid used to search for this guild
    */
-  constructor (data) {
+  constructor (data, me = '') {
     /**
      * Guild ID
      * @type {string}
@@ -41,6 +42,11 @@ class Guild {
      * @type {Array<GuildMember>}
      */
     this.members = members(data);
+    /**
+     * Me, if a player UUID is used to get the guild
+     * @type {GuildMember|null}
+     */
+    this.me = this.members.find((member)=> member.uuid === me);
     /**
      * Guild ranks
      * @type {Array<GuildRank>}

--- a/src/structures/MiniGames/SkyWarsRanked.js
+++ b/src/structures/MiniGames/SkyWarsRanked.js
@@ -21,6 +21,25 @@ class SkyWarsRanked {
      * @type {number}
      */
     this.rating = data.score;
+    /**
+     * Season key parsed as date, should usually be current season
+     * @type {Date}
+     */
+    this.date = getDateFromKey(this.seasonKey);
   }
 }
+
+/**
+ * Gets date from season key
+ * @param {string} key Season Key
+ * @return {Date|null}
+ */
+function getDateFromKey(key) {
+  const initDate = new Date(1000 * 60 * 60 * 5);
+  const [month, year] = key.split('_').map(Number);
+  // month needs to be 0 indexed cuz js :)
+  if (isNaN(month) || isNaN(year) || month > 11) return null;
+  return new Date(initDate.setFullYear(2000 + year, month - 1, 1));
+}
+
 module.exports = SkyWarsRanked;

--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -31,9 +31,10 @@ const Warlords = require('./MiniGames/Warlords');
 class Player {
   /**
    * @param {object} data Player data
-   * @param {object} fakethis
+   * @param {object} fakethis Will be deprecated
+   * @param {Record<string, any>} extraPayload extra data requested alongside player
    */
-  constructor (data, fakethis) {
+  constructor (data, fakethis, extraPayload) {
     /**
      * Player nickname
      * @type {string}
@@ -208,16 +209,27 @@ class Player {
     /**
      * Player recent games
      * @return {Promise<Array<RecentGame>>}
+     * @deprecated
      */
     this.getRecentGames = function () {
       return getRecentGames.call(fakethis, this.uuid, this);
     };
     /**
+     * Player's Guild if requested in options
+     * @type {Guild|null}
+     */
+    this.guild = extraPayload?.guild || null;
+    /**
+     * Recent Games if requested in options
+     * @type {RecentGame[]|null}
+     */
+    this.recentGames = extraPayload?.recentGames || null;
+    /**
      * Player stats for each mini-game
      * @type {PlayerStats}
      */
     this.stats = (data.stats ? {
-      skywars: (data.stats.SkyWars ? new SkyWars(data.stats.SkyWars) : null),
+      skywars: (data.stats.SkyWars ? new SkyWars(data.stats.SkyWars, extraPayload?.rankedSW || null) : null),
       bedwars: (data.stats.Bedwars ? new BedWars(data.stats.Bedwars) : null),
       uhc: (data.stats.UHC ? new UHC(data.stats.UHC) : null),
       speeduhc: (data.stats.SpeedUHC ? new SpeedUHC(data.stats.SpeedUHC) : null),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -383,7 +383,7 @@ declare module 'hypixel-api-reborn' {
       arcade?: Arcade
     };
     getRecentGames(): Promise<RecentGame[]>;
-    recentGames?: null;
+    recentGames?: RecentGame[];
     toString(): string;
   }
   class SkyWarsRanked {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -33,7 +33,9 @@ export interface methodOptions {
   noCaching?: boolean;
 }
 export interface playerMethodOptions extends methodOptions {
+  currentRankedSW?: boolean;
   guild?: boolean;
+  recentGames?: boolean;
 }
 export interface skyblockMemberOptions extends methodOptions {
   fetchPlayer?: boolean;
@@ -381,12 +383,14 @@ declare module 'hypixel-api-reborn' {
       arcade?: Arcade
     };
     getRecentGames(): Promise<RecentGame[]>;
+    recentGames?: null;
     toString(): string;
   }
   class SkyWarsRanked {
     constructor(data: Record<string, unknown>);
     seasonKey: string;
     rating: number;
+    date: Date;
     position: number;
   }
   class PlayerCosmetics {


### PR DESCRIPTION
**Please describe changes**
```diff
+ date property for Ranked SW
- removed 0 padding for previous rsw ratings' parser.
+ reformatted rsw rating parser in <Skywars> for better readability
+ guild.members.me whenever possible (searching guild by player uuid, player endpoint guild option)
+ Ability to issue multiple player-related request from getPlayer : guild, recentGames, currentRankedSW ( last one will get injected directly into SkyWars#ranked#ratings ).
- Marked getRecentGames as deprecated ( so fakethis as well ) because it is unneeded with the addition above^.
+ package.json update self version to 8.3.0 (ig)
```
Shouldn't have any breaking changes

*Description*

- [x] I've added new features. (methods or parameters)
- [x] I've added jsdoc and typings.
- [ ] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)