### PR TITLE
Updated player structure to new Hypixel staff ranks

### DIFF
--- a/src/structures/Player.js
+++ b/src/structures/Player.js
@@ -283,14 +283,11 @@ function getRank (player) {
     rank = player.prefix.replace(/§[0-9|a-z]|\[|\]/g, '');
   } else if (player.rank && player.rank !== 'NORMAL') {
     switch (player.rank) {
-      case 'MODERATOR':
-        rank = 'Moderator';
-        break;
       case 'YOUTUBER':
         rank = 'YouTube';
         break;
-      case 'HELPER':
-        rank = 'Helper';
+      case 'GAME_MASTER':
+        rank = 'Game Master';
         break;
       case 'ADMIN':
         rank = 'Admin';
@@ -401,8 +398,7 @@ function parseClaimedRewards (data) {
  * * `MVP`
  * * `MVP+`
  * * `MVP++`
- * * `Helper`
- * * `Moderator`
+ * * `Game Master`
  * * `Admin`
  * * `YouTube`
  */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,7 +6,7 @@
 
 import { EventEmitter } from 'events';
 
-export type PLAYER_RANK = 'Default' | 'VIP' | 'VIP+' | 'MVP' | 'MVP+' | 'MVP++' | 'YouTube' | 'Helper' | 'Moderator' | 'Admin';
+export type PLAYER_RANK = 'Default' | 'VIP' | 'VIP+' | 'MVP' | 'MVP+' | 'MVP++' | 'YouTube' | 'Game Master' | 'Admin';
 export type GAME_NAME = 'Quake Craft' | 'Walls' | 'Paintball' | 'Blitz Survival Games' | 'The TNT Games' | 'VampireZ' | 'Mega Walls' | 'Arcade' | 'Arena Walls' | 'UHC Champions' | 'Cops and Crims' | 'Warlords' | 'Smash Heroes' | 'Turbo Kart Racing' | 'Housing' | 'SkyWars' | 'Crazy Walls' | 'Speed UHC' | 'SkyClash' | 'Classic Games' | 'Prototype' | 'BedWars' | 'Murder Mystery' | 'Build Battle' | 'Duels' | 'SkyBlock' | 'The Pit' | 'Replay' | 'Limbo' | 'Queue' | 'Main Lobby' | 'Tournament Lobby' | 'Idle';
 export type GAME_ID = 2 | 3 | 4 | 5 | 6 | 7 | 13 | 14 | 17 | 20 | 21 | 23 | 24 | 25 | 26 | 51 | 52 | 54 | 55 | 56 | 57 | 58 | 59 | 60 | 61 | 63 | 64 | -1 | -2 | -3 | -4 | -5 | -6;
 export type GAME_CODE = 'QUAKECRAFT' | 'WALLS' | 'PAINTBALL' | 'SURVIVAL_GAMES' | 'TNTGAMES' | 'VAMPIREZ' | 'WALLS3' | 'ARCADE' | 'UHC' | 'MCGO' | 'BATTLEGROUND' | 'SUPER_SMASH' | 'GINGERBREAD' | 'HOUSING' | 'SKYWARS' | 'TRUE_COMBAT' | 'SPEED_UHC' | 'SKYCLASH' | 'LEGACY' | 'PROTOTYPE' | 'BEDWARS' | 'MURDER_MYSTERY' | 'BUILD_BATTLE' | 'DUELS' | 'SKYBLOCK' | 'PIT' | 'REPLAY' | 'LIMBO' | 'IDLE' | 'QUEUE' | 'MAIN_LOBBY' | 'TOURNAMENT_LOBBY';


### PR DESCRIPTION
The 'MODERATOR' and 'HELPER' ranks have been removed, and replaced by the 'GAME_MASTER' rank.

*Description*
I removed the moderator and helper rank from the staff rank switch, and added the game master rank to it. I tested the code & also changed the typings for it. I can't find it in the docs so it's probably just not in there.