### PR TITLE
fix(prismarine): HAR breaks when used in conjunction with use strict

### DIFF
--- a/src/structures/ItemBytes.js
+++ b/src/structures/ItemBytes.js
@@ -1,5 +1,4 @@
-const nbt = require('prismarine-nbt');
-const parseNbt = (require('util')).promisify(nbt.parse);
+const { decode } = require('../utils/SkyblockUtils');
 /**
  * Item Bytes class
  */
@@ -28,9 +27,7 @@ class ItemBytes {
    * @return {any[]}
    */
   async readNBT () {
-    let data = await parseNbt(this.bytesBuffer);
-    data = nbt.simplify(data);
-    return Array.from(data.i);
+    return await decode(this.bytesBuffer, true);
   }
 }
 module.exports = ItemBytes;

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -1,10 +1,10 @@
 /* eslint-disable camelcase */
 const constants = require('./Constants');
 module.exports = {
-  async decode (base64) {
+  async decode (base64, buffer=false) {
     const nbt = require('prismarine-nbt');
     const parseNbt = (require('util')).promisify(nbt.parse);
-    const buffer = Buffer.from(base64, 'base64');
+    const buffer = buffer ? base64 : Buffer.from(base64, 'base64');
     let data = await parseNbt(buffer);
     data = nbt.simplify(data);
     const newdata = [];


### PR DESCRIPTION
**Please describe changes**
(Refer to discord)
When using `'use strict';`, hypixel-api-reborn will cause an error because prismarine-nbt uses `eval`, unsafe code :/. 
In this PR, the `readNBT` function for class `ItemBytes` is migrated to `decode` in `SkyblockUtils`, and `prismarine-nbt` is now required inside the function, therefore avoiding the error for ppl that don't touch prismarine-nbt usually.

If you do need to use prismarine-nbt however, use strict will not be compatible with it and that's not our problem :p 

*Description*

- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)