### PR TITLE
Fixes Client before initialization

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
-const client = new Client(process.env.HYPIXEL_KEY, { cache: true });
 const { Client, Game, SkyWars, BedWars, UHC, SpeedUHC, MurderMystery, Duels, BuildBattle, MegaWalls, CopsAndCrims, TNTGames, SmashHeroes, VampireZ, BlitzSurvivalGames, ArenaBrawl, Guild, PlayerCosmetics, Pets, Pet, Color, ServerInfo, WoolWars } = require('../src');
+const client = new Client(process.env.HYPIXEL_KEY, { cache: true });
 const { expect } = require('chai');
 describe('Client#getPlayer', () => {
   let player;


### PR DESCRIPTION
**Please describe changes**
When running `npm run tests` You would get `ReferenceError: Cannot access 'Client' before initialization` This was because it got moved up a line in #421 

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (*optional* you can mention a issue if there is one) - ReferenceError: Cannot access 'Client' before initialization. Has been fixed
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)