### PR TITLE
proposal(remove textContent)

### DIFF
--- a/src/structures/APIIncident.js
+++ b/src/structures/APIIncident.js
@@ -43,12 +43,6 @@ class APIIncident {
      */
     this.snippet = data.contentSnippet || null;
     /**
-     * Content as plain text
-     * The parsing might be faulty!
-     * @type {string|null}
-     */
-    this.TextContent = (data.content || '').replace(/<[^>]+>/g, '') || null;
-    /**
      * GUID
      * @type {string|null}
      */

--- a/src/structures/APIIncident.js
+++ b/src/structures/APIIncident.js
@@ -58,14 +58,14 @@ class APIIncident {
      * @type {boolean}
      * @version >6.0.1
      */
-    this.isResolved = this.TextContent.includes('Resolved -') || this.TextContent.includes('Completed -');
+    this.isResolved = this.HTMLContent.includes('Resolved -') || this.HTMLContent.includes('Completed -');
   }
   /**
-   * Text Content
+   * HTML Content
    * @return {string}
    */
   toString() {
-    return this.TextContent;
+    return this.HTMLContent;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3583,7 +3583,6 @@ declare module 'hypixel-api-reborn' {
     startTimestamp: number;
     author: string;
     HTMLContent: string;
-    TextContent: string;
     snippet: string;
     guid: string;
     categories: string[];


### PR DESCRIPTION
**Please describe changes**
- Removes "textContent" from API Incident as it is completely useless. It includes scripts and styles...
- If users want to display the entire incident page they can use an external library to parse the HTML and extract relevant text content. I personally do not see the point of this anyway, as you can a) display the snippet and b) link to the whole incident page
- Also fixes 1 high security (not rly high imo) issue

## Checks
- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [ ] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run test`)
- [x] I've check for issues. (`npm run eslint`)
- [x] I've fixed my formatting. (`npm run prettier`)
