### PR TITLE
fix(Skyhelper-Networth): Change cache to fix module stalling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "object-path": "^0.11.8",
     "prismarine-nbt": "^2.5.0",
     "rss-parser": "^3.13.0",
-    "skyhelper-networth": "^1.18.4"
+    "skyhelper-networth": "git+https://github.com/ChiefChippy2/SkyHelper-Networth.git#patch-1"
   },
   "license": "MIT",
   "readme": "https://hypixel.stavzdev.me/",


### PR DESCRIPTION
**Please describe changes**
Changed Networth to my patch (pull from github)
_Description_

This is because master has a defective JSON cache and therefore might cause the module to indefinitely fail or hang if a request fails (even temporarily)... my fix which I tested by turning off wifi doesn't have this issue as far as I can tell.
waiting for maintainers of skyhelper to merge my PR but they seem to be unresponsive hence this PR to use my branch for the next release unless ofc they release new npm version with my pr

- [ ] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [ ] I've tested my code. (`npm run test`)
- [ ] I've check for issues. (`npm run eslint`)
- [ ] I've fixed my formatting. (`npm run prettier`)
