### PR TITLE
fix: undefined errors caused by missing optional chaining

### DIFF
--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -90,7 +90,7 @@ class SkyblockMember {
      * Trophy fish amount of rewards
      * @type {number}
      */
-    this.trophyFish = getTrophyFishRank(data.m.trophy_fish?.rewards.length ?? 0);
+    this.trophyFish = getTrophyFishRank(data.m.trophy_fish?.rewards?.length ?? 0);
     /**
      * The highest magical power **Not current one**
      * @type {number}

--- a/src/structures/SkyBlock/SkyblockMember.js
+++ b/src/structures/SkyBlock/SkyblockMember.js
@@ -307,7 +307,7 @@ class SkyblockMember {
      */
     this.getNetworth = async () => {
       try {
-        const nw = await skyhelper.getNetworth(data.m, data.banking.balance ?? 0, {
+        const nw = await skyhelper.getNetworth(data.m, data.banking?.balance ?? 0, {
           onlyNetworth: true,
           v2Endpoint: true,
           cache: true,


### PR DESCRIPTION
## Changes
- Add optional chaining operator to banking and trophy fish api

<!-- A clear and detailed description of the changes that you have done -->

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run tests`)
- [x] I've check for issues. (`npm run eslint`)
- [x] I've fixed my formatting. (`npm run prettier`)

</details>
