### PR TITLE
add garden to SkyblockProfile

### DIFF
--- a/src/structures/SkyBlock/SkyblockProfile.js
+++ b/src/structures/SkyBlock/SkyblockProfile.js
@@ -1,3 +1,4 @@
+const SkyblockGarden = require('./SkyblockGarden');
 const SkyblockMember = require('./SkyblockMember');
 /**
  * Skyblock Profile class
@@ -29,6 +30,11 @@ class SkyblockProfile {
      */
     this.banking = data.banking;
     /**
+     * Profile's garden
+     * @type {SkyblockGarden|null}
+     */
+    this.garden = data.garden || null;
+    /**
      * Profile's community upgrades
      * @type {object}
      */
@@ -53,6 +59,7 @@ class SkyblockProfile {
           banking: this.banking,
           communityUpgrades: this.communityUpgrades,
           museum: null,
+          garden: this.garden,
           selected: this.selected
         })
     );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2591,6 +2591,7 @@ declare module 'hypixel-api-reborn' {
     members: SkyblockMember[];
     me: SkyblockMember;
     selected: boolean;
+    garden?: SkyblockGarden;
   }
   class SkyblockPet {
     constructor(data: Record<string, unknown>);


### PR DESCRIPTION
## Changes
This adds garden on a profile when using getSkyblockProfile and passes the garden down to its members.
<!-- A clear and detailed description of the changes that you have done -->

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [ ] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [ ] I've tested my code. (`npm run tests`)
- [ ] I've check for issues. (`npm run eslint`)
- [ ] I've fixed my formatting. (`npm run prettier`)

</details>
