### PR TITLE
Fix/garden coco beans

### DIFF
--- a/src/API/skyblock/getGarden.js
+++ b/src/API/skyblock/getGarden.js
@@ -1,7 +1,10 @@
 module.exports = async function (profileId) {
   const SkyblockGarden = require('../../structures/SkyBlock/SkyblockGarden');
+  let res;
   // eslint-disable-next-line no-underscore-dangle
-  const res = await this._makeRequest(`/skyblock/garden?profile=${profileId}`);
-  if (res.raw) return res;
+  try {
+      res = await this._makeRequest(`/skyblock/garden?profile=${profileId}`);
+  } catch(e) {}
+  if (res?.raw) return res;
   return new SkyblockGarden(res);
 };

--- a/src/structures/SkyBlock/SkyblockGarden.js
+++ b/src/structures/SkyBlock/SkyblockGarden.js
@@ -47,7 +47,7 @@ class SkyblockGarden {
       pumpkin: getLevelByXp(data.garden?.resources_collected?.PUMPKIN || 0, 'pumpkin'),
       melon: getLevelByXp(data.garden?.resources_collected?.MELON || 0, 'melon'),
       cactus: getLevelByXp(data.garden?.resources_collected?.CACTUS || 0, 'cactus'),
-      cocoBeans: getLevelByXp(data.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoBeans'),
+      cocoaBeans: getLevelByXp(data.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoaBeans'),
       mushroom: getLevelByXp(data.garden?.resources_collected?.MUSHROOM_COLLECTION || 0, 'mushroom'),
       netherWart: getLevelByXp(data.garden?.resources_collected?.NETHER_STALK || 0, 'netherWart')
     };
@@ -81,7 +81,7 @@ class SkyblockGarden {
       pumpkin: data.garden?.crop_upgrade_levels?.PUMPKIN || 0,
       melon: data.garden?.crop_upgrade_levels?.MELON || 0,
       cactus: data.garden?.crop_upgrade_levels?.CACTUS || 0,
-      cocoBeans: data.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
+      cocoaBeans: data.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
       mushroom: data.garden?.crop_upgrade_levels?.MUSHROOM_COLLECTION || 0,
       netherWart: data.garden?.crop_upgrade_levels?.NETHER_STALK || 0
     };
@@ -125,7 +125,7 @@ class SkyblockGarden {
  * @property {number} pumpkin Pumpkin
  * @property {number} melon Melon
  * @property {number} cactus Cactus
- * @property {number} cocoBeans Coco Beans
+ * @property {number} cocoaBeans Coco Beans
  * @property {number} mushroom Mushroom
  * @property {number} netherWart Nether Wart
  */
@@ -138,7 +138,7 @@ class SkyblockGarden {
  * @property {SkyblockSkillLevel} pumpkin Pumpkin
  * @property {SkyblockSkillLevel} melon Melon
  * @property {SkyblockSkillLevel} cactus Cactus
- * @property {SkyblockSkillLevel} cocoBeans Coco Beans
+ * @property {SkyblockSkillLevel} cocoaBeans Coco Beans
  * @property {SkyblockSkillLevel} mushroom Mushroom
  * @property {SkyblockSkillLevel} netherWart Nether Wart
  */

--- a/src/structures/SkyBlock/SkyblockGarden.js
+++ b/src/structures/SkyBlock/SkyblockGarden.js
@@ -17,22 +17,22 @@ class SkyblockGarden {
      * Current Barn Skin
      * @type {string}
      */
-    this.barnSkin = data.garden?.selected_barn_skin || '';
+    this.barnSkin = data?.garden?.selected_barn_skin || '';
     /**
      * Unlocked Plots
      * @type {string[]}
      */
-    this.unlockedPlots = data.garden?.unlocked_plots_ids || [];
+    this.unlockedPlots = data?.garden?.unlocked_plots_ids || [];
     /**
      * Visitor Stats
      * @type {SkyblockGardenVisitor}
      */
     this.visitors = {
-      visited: data.garden?.commission_data?.visits || {},
-      completed: data.garden?.commission_data?.completed || {},
+      visited: data?.garden?.commission_data?.visits || {},
+      completed: data?.garden?.commission_data?.completed || {},
       served: {
-        total: data.garden?.commission_data?.total_completed || 0,
-        unique: data.garden?.commission_data?.unique_npcs_served || 0
+        total: data?.garden?.commission_data?.total_completed || 0,
+        unique: data?.garden?.commission_data?.unique_npcs_served || 0
       }
     };
     /**
@@ -40,33 +40,33 @@ class SkyblockGarden {
      * @type {SkyblockGarenCropMilestones}
      */
     this.cropMilestones = {
-      wheat: getLevelByXp(data.garden?.resources_collected?.WHEAT || 0, 'wheat'),
-      carrot: getLevelByXp(data.garden?.resources_collected?.CARROT_ITEM || 0, 'carrot'),
-      sugarCane: getLevelByXp(data.garden?.resources_collected?.SUGAR_CANE || 0, 'sugarCane'),
-      potato: getLevelByXp(data.garden?.resources_collected?.POTATO_ITEM || 0, 'potato'),
-      pumpkin: getLevelByXp(data.garden?.resources_collected?.PUMPKIN || 0, 'pumpkin'),
-      melon: getLevelByXp(data.garden?.resources_collected?.MELON || 0, 'melon'),
-      cactus: getLevelByXp(data.garden?.resources_collected?.CACTUS || 0, 'cactus'),
-      cocoBeans: getLevelByXp(data.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoBeans'),
-      mushroom: getLevelByXp(data.garden?.resources_collected?.MUSHROOM_COLLECTION || 0, 'mushroom'),
-      netherWart: getLevelByXp(data.garden?.resources_collected?.NETHER_STALK || 0, 'netherWart')
+      wheat: getLevelByXp(data?.garden?.resources_collected?.WHEAT || 0, 'wheat'),
+      carrot: getLevelByXp(data?.garden?.resources_collected?.CARROT_ITEM || 0, 'carrot'),
+      sugarCane: getLevelByXp(data?.garden?.resources_collected?.SUGAR_CANE || 0, 'sugarCane'),
+      potato: getLevelByXp(data?.garden?.resources_collected?.POTATO_ITEM || 0, 'potato'),
+      pumpkin: getLevelByXp(data?.garden?.resources_collected?.PUMPKIN || 0, 'pumpkin'),
+      melon: getLevelByXp(data?.garden?.resources_collected?.MELON || 0, 'melon'),
+      cactus: getLevelByXp(data?.garden?.resources_collected?.CACTUS || 0, 'cactus'),
+      cocoBeans: getLevelByXp(data?.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoBeans'),
+      mushroom: getLevelByXp(data?.garden?.resources_collected?.MUSHROOM_COLLECTION || 0, 'mushroom'),
+      netherWart: getLevelByXp(data?.garden?.resources_collected?.NETHER_STALK || 0, 'netherWart')
     };
     /**
      * Composter
      * @type {SkyblockGardenComposter}
      */
     this.composter = {
-      organicMatter: data.garden?.composter_data?.organic_matter || 0,
-      fuelUnits: data.garden?.composter_data?.fuel_units || 0,
-      compostUnits: data.garden?.composter_data?.compost_units || 0,
-      compostItems: data.garden?.composter_data?.compost_items || 0,
-      conversionTicks: data.garden?.composter_data?.conversion_ticks || 0,
+      organicMatter: data?.garden?.composter_data?.organic_matter || 0,
+      fuelUnits: data?.garden?.composter_data?.fuel_units || 0,
+      compostUnits: data?.garden?.composter_data?.compost_units || 0,
+      compostItems: data?.garden?.composter_data?.compost_items || 0,
+      conversionTicks: data?.garden?.composter_data?.conversion_ticks || 0,
       upgrades: {
-        speed: data.garden?.composter_data?.upgrades?.speed || 0,
-        multiDrop: data.garden?.composter_data?.upgrades?.multi_drop || 0,
-        fuelCap: data.garden?.composter_data?.upgrades?.fuel_cap || 0,
-        organicMatterCap: data.garden?.composter_data?.upgrades?.organic_matter_cap || 0,
-        costReduction: data.garden?.composter_data?.upgrades?.cost_reduction || 0
+        speed: data?.garden?.composter_data?.upgrades?.speed || 0,
+        multiDrop: data?.garden?.composter_data?.upgrades?.multi_drop || 0,
+        fuelCap: data?.garden?.composter_data?.upgrades?.fuel_cap || 0,
+        organicMatterCap: data?.garden?.composter_data?.upgrades?.organic_matter_cap || 0,
+        costReduction: data?.garden?.composter_data?.upgrades?.cost_reduction || 0
       }
     };
     /**
@@ -74,16 +74,16 @@ class SkyblockGarden {
      * @type {SkyblockGarenCrops}
      */
     this.cropUpgrades = {
-      wheat: data.garden?.crop_upgrade_levels?.WHEAT || 0,
-      carrot: data.garden?.crop_upgrade_levels?.CARROT_ITEM || 0,
-      sugarCane: data.garden?.crop_upgrade_levels?.SUGAR_CANE || 0,
-      potato: data.garden?.crop_upgrade_levels?.POTATO_ITEM || 0,
-      pumpkin: data.garden?.crop_upgrade_levels?.PUMPKIN || 0,
-      melon: data.garden?.crop_upgrade_levels?.MELON || 0,
-      cactus: data.garden?.crop_upgrade_levels?.CACTUS || 0,
-      cocoBeans: data.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
-      mushroom: data.garden?.crop_upgrade_levels?.MUSHROOM_COLLECTION || 0,
-      netherWart: data.garden?.crop_upgrade_levels?.NETHER_STALK || 0
+      wheat: data?.garden?.crop_upgrade_levels?.WHEAT || 0,
+      carrot: data?.garden?.crop_upgrade_levels?.CARROT_ITEM || 0,
+      sugarCane: data?.garden?.crop_upgrade_levels?.SUGAR_CANE || 0,
+      potato: data?.garden?.crop_upgrade_levels?.POTATO_ITEM || 0,
+      pumpkin: data?.garden?.crop_upgrade_levels?.PUMPKIN || 0,
+      melon: data?.garden?.crop_upgrade_levels?.MELON || 0,
+      cactus: data?.garden?.crop_upgrade_levels?.CACTUS || 0,
+      cocoBeans: data?.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
+      mushroom: data?.garden?.crop_upgrade_levels?.MUSHROOM_COLLECTION || 0,
+      netherWart: data?.garden?.crop_upgrade_levels?.NETHER_STALK || 0
     };
   }
 }

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -50,7 +50,7 @@ function getLevelByXp(xp, type, levelCap) {
     case 'sugarCane':
       xpTable = constants.sugarCane;
       break;
-    case 'cocoBeans':
+    case 'cocoaBeans':
       xpTable = constants.cocoaBeans;
       break;
     case 'cactus':

--- a/src/utils/SkyblockUtils.js
+++ b/src/utils/SkyblockUtils.js
@@ -50,7 +50,7 @@ function getLevelByXp(xp, type, levelCap) {
     case 'sugarCane':
       xpTable = constants.sugarCane;
       break;
-    case 'cocoaBeans':
+    case 'cocoBeans':
       xpTable = constants.cocoaBeans;
       break;
     case 'cactus':

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -308,7 +308,7 @@ export interface SKYBLOCK_GARDEN_CROPS {
   pumpkin: number;
   melon: number;
   cactus: number;
-  cocoBeans: number;
+  cocoaBeans: number;
   mushroom: number;
   netherWart: number;
 }
@@ -2625,7 +2625,7 @@ declare module 'hypixel-api-reborn' {
       pumpkin: SKYBLOCK_SKILL_DATA;
       melon: SKYBLOCK_SKILL_DATA;
       cactus: SKYBLOCK_SKILL_DATA;
-      cocoBeans: SKYBLOCK_SKILL_DATA;
+      cocoaBeans: SKYBLOCK_SKILL_DATA;
       mushroom: SKYBLOCK_SKILL_DATA;
       netherWart: SKYBLOCK_SKILL_DATA;
     };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2686,7 +2686,7 @@ declare module 'hypixel-api-reborn' {
     dungeons: {
       types: {
         catacombs: {
-          experience: number;
+          experience: SKYBLOCK_SKILL_DATA;
           completions: Record<string, number>;
         };
         masterCatacombs: {


### PR DESCRIPTION
## Changes
This PR fixes the spelling of cocoaBeans that resulted in wrong xpTable being used.
<!-- A clear and detailed description of the changes that you have done -->

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [ ] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [ ] I've tested my code. (`npm run tests`)
- [ ] I've check for issues. (`npm run eslint`)
- [ ] I've fixed my formatting. (`npm run prettier`)

</details>
