### PR TITLE
fix getSkyblockGarden throwing error when user has no garden data

### DIFF
--- a/src/API/skyblock/getGarden.js
+++ b/src/API/skyblock/getGarden.js
@@ -1,7 +1,11 @@
 module.exports = async function (profileId) {
   const SkyblockGarden = require('../../structures/SkyBlock/SkyblockGarden');
-  // eslint-disable-next-line no-underscore-dangle
-  const res = await this._makeRequest(`/skyblock/garden?profile=${profileId}`);
-  if (res.raw) return res;
+  let res;
+  try {
+    // eslint-disable-next-line no-underscore-dangle
+    res = await this._makeRequest(`/skyblock/garden?profile=${profileId}`).catch();
+    // eslint-disable-next-line no-unused-vars, no-empty
+  } catch (e) {}
+  if (res?.raw) return res;
   return new SkyblockGarden(res);
 };

--- a/src/structures/SkyBlock/SkyblockGarden.js
+++ b/src/structures/SkyBlock/SkyblockGarden.js
@@ -17,22 +17,22 @@ class SkyblockGarden {
      * Current Barn Skin
      * @type {string}
      */
-    this.barnSkin = data.garden?.selected_barn_skin || '';
+    this.barnSkin = data?.garden?.selected_barn_skin || '';
     /**
      * Unlocked Plots
      * @type {string[]}
      */
-    this.unlockedPlots = data.garden?.unlocked_plots_ids || [];
+    this.unlockedPlots = data?.garden?.unlocked_plots_ids || [];
     /**
      * Visitor Stats
      * @type {SkyblockGardenVisitor}
      */
     this.visitors = {
-      visited: data.garden?.commission_data?.visits || {},
-      completed: data.garden?.commission_data?.completed || {},
+      visited: data?.garden?.commission_data?.visits || {},
+      completed: data?.garden?.commission_data?.completed || {},
       served: {
-        total: data.garden?.commission_data?.total_completed || 0,
-        unique: data.garden?.commission_data?.unique_npcs_served || 0
+        total: data?.garden?.commission_data?.total_completed || 0,
+        unique: data?.garden?.commission_data?.unique_npcs_served || 0
       }
     };
     /**
@@ -40,33 +40,33 @@ class SkyblockGarden {
      * @type {SkyblockGarenCropMilestones}
      */
     this.cropMilestones = {
-      wheat: getLevelByXp(data.garden?.resources_collected?.WHEAT || 0, 'wheat'),
-      carrot: getLevelByXp(data.garden?.resources_collected?.CARROT_ITEM || 0, 'carrot'),
-      sugarCane: getLevelByXp(data.garden?.resources_collected?.SUGAR_CANE || 0, 'sugarCane'),
-      potato: getLevelByXp(data.garden?.resources_collected?.POTATO_ITEM || 0, 'potato'),
-      pumpkin: getLevelByXp(data.garden?.resources_collected?.PUMPKIN || 0, 'pumpkin'),
-      melon: getLevelByXp(data.garden?.resources_collected?.MELON || 0, 'melon'),
-      cactus: getLevelByXp(data.garden?.resources_collected?.CACTUS || 0, 'cactus'),
-      cocoaBeans: getLevelByXp(data.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoaBeans'),
-      mushroom: getLevelByXp(data.garden?.resources_collected?.MUSHROOM_COLLECTION || 0, 'mushroom'),
-      netherWart: getLevelByXp(data.garden?.resources_collected?.NETHER_STALK || 0, 'netherWart')
+      wheat: getLevelByXp(data?.garden?.resources_collected?.WHEAT || 0, 'wheat'),
+      carrot: getLevelByXp(data?.garden?.resources_collected?.CARROT_ITEM || 0, 'carrot'),
+      sugarCane: getLevelByXp(data?.garden?.resources_collected?.SUGAR_CANE || 0, 'sugarCane'),
+      potato: getLevelByXp(data?.garden?.resources_collected?.POTATO_ITEM || 0, 'potato'),
+      pumpkin: getLevelByXp(data?.garden?.resources_collected?.PUMPKIN || 0, 'pumpkin'),
+      melon: getLevelByXp(data?.garden?.resources_collected?.MELON || 0, 'melon'),
+      cactus: getLevelByXp(data?.garden?.resources_collected?.CACTUS || 0, 'cactus'),
+      cocoaBeans: getLevelByXp(data?.garden?.resources_collected?.['INK_SACK:3'] || 0, 'cocoaBeans'),
+      mushroom: getLevelByXp(data?.garden?.resources_collected?.MUSHROOM_COLLECTION || 0, 'mushroom'),
+      netherWart: getLevelByXp(data?.garden?.resources_collected?.NETHER_STALK || 0, 'netherWart')
     };
     /**
      * Composter
      * @type {SkyblockGardenComposter}
      */
     this.composter = {
-      organicMatter: data.garden?.composter_data?.organic_matter || 0,
-      fuelUnits: data.garden?.composter_data?.fuel_units || 0,
-      compostUnits: data.garden?.composter_data?.compost_units || 0,
-      compostItems: data.garden?.composter_data?.compost_items || 0,
-      conversionTicks: data.garden?.composter_data?.conversion_ticks || 0,
+      organicMatter: data?.garden?.composter_data?.organic_matter || 0,
+      fuelUnits: data?.garden?.composter_data?.fuel_units || 0,
+      compostUnits: data?.garden?.composter_data?.compost_units || 0,
+      compostItems: data?.garden?.composter_data?.compost_items || 0,
+      conversionTicks: data?.garden?.composter_data?.conversion_ticks || 0,
       upgrades: {
-        speed: data.garden?.composter_data?.upgrades?.speed || 0,
-        multiDrop: data.garden?.composter_data?.upgrades?.multi_drop || 0,
-        fuelCap: data.garden?.composter_data?.upgrades?.fuel_cap || 0,
-        organicMatterCap: data.garden?.composter_data?.upgrades?.organic_matter_cap || 0,
-        costReduction: data.garden?.composter_data?.upgrades?.cost_reduction || 0
+        speed: data?.garden?.composter_data?.upgrades?.speed || 0,
+        multiDrop: data?.garden?.composter_data?.upgrades?.multi_drop || 0,
+        fuelCap: data?.garden?.composter_data?.upgrades?.fuel_cap || 0,
+        organicMatterCap: data?.garden?.composter_data?.upgrades?.organic_matter_cap || 0,
+        costReduction: data?.garden?.composter_data?.upgrades?.cost_reduction || 0
       }
     };
     /**
@@ -74,16 +74,16 @@ class SkyblockGarden {
      * @type {SkyblockGarenCrops}
      */
     this.cropUpgrades = {
-      wheat: data.garden?.crop_upgrade_levels?.WHEAT || 0,
-      carrot: data.garden?.crop_upgrade_levels?.CARROT_ITEM || 0,
-      sugarCane: data.garden?.crop_upgrade_levels?.SUGAR_CANE || 0,
-      potato: data.garden?.crop_upgrade_levels?.POTATO_ITEM || 0,
-      pumpkin: data.garden?.crop_upgrade_levels?.PUMPKIN || 0,
-      melon: data.garden?.crop_upgrade_levels?.MELON || 0,
-      cactus: data.garden?.crop_upgrade_levels?.CACTUS || 0,
-      cocoaBeans: data.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
-      mushroom: data.garden?.crop_upgrade_levels?.MUSHROOM_COLLECTION || 0,
-      netherWart: data.garden?.crop_upgrade_levels?.NETHER_STALK || 0
+      wheat: data?.garden?.crop_upgrade_levels?.WHEAT || 0,
+      carrot: data?.garden?.crop_upgrade_levels?.CARROT_ITEM || 0,
+      sugarCane: data?.garden?.crop_upgrade_levels?.SUGAR_CANE || 0,
+      potato: data?.garden?.crop_upgrade_levels?.POTATO_ITEM || 0,
+      pumpkin: data?.garden?.crop_upgrade_levels?.PUMPKIN || 0,
+      melon: data?.garden?.crop_upgrade_levels?.MELON || 0,
+      cactus: data?.garden?.crop_upgrade_levels?.CACTUS || 0,
+      cocoaBeans: data?.garden?.crop_upgrade_levels?.['INK_SACK:3'] || 0,
+      mushroom: data?.garden?.crop_upgrade_levels?.MUSHROOM_COLLECTION || 0,
+      netherWart: data?.garden?.crop_upgrade_levels?.NETHER_STALK || 0
     };
   }
 }


### PR DESCRIPTION
## Changes
This prevents the code from crashing if the Skyblock profile has no garden

<!-- A clear and detailed description of the changes that you have done -->

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [ ] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [ ] I've tested my code. (`npm run tests`)
- [ ] I've check for issues. (`npm run eslint`)
- [ ] I've fixed my formatting. (`npm run prettier`)

</details>
