### PR TITLE
fix: gexp totalHistory summing in the wrong order

### DIFF
--- a/src/utils/Guild.js
+++ b/src/utils/Guild.js
@@ -9,9 +9,6 @@ function parseDate(date) {
 
 function parseHistory(historyData) {
   const expValuesReversed = Object.values(historyData).reverse();
-  const maxToIndex = (index) => {
-      return expValuesReversed.slice(0, expValuesReversed.length - index).reduce((pV, cV) => pV + cV);
-  };
 
   return Object.entries(historyData).map((x, index) => ({
     day: x[0],
@@ -23,7 +20,9 @@ function parseHistory(historyData) {
           .map((x) => parseInt(x, 10))
       ) || undefined,
     exp: x[1] || 0,
-    totalExp: maxToIndex(index)
+    totalExp: expValuesReversed
+      .slice(0, expValuesReversed.length - index)
+      .reduce((pV, cV) => pV + cV)
   }));
 }
 

--- a/src/utils/Guild.js
+++ b/src/utils/Guild.js
@@ -8,6 +8,11 @@ function parseDate(date) {
 }
 
 function parseHistory(historyData) {
+  const expValuesReversed = Object.values(historyData).reverse();
+  const maxToIndex = (index) => {
+      return expValuesReversed.slice(0, expValuesReversed.length - index).reduce((pV, cV) => pV + cV);
+  }
+
   return Object.entries(historyData).map((x, index) => ({
     day: x[0],
     date:
@@ -18,9 +23,7 @@ function parseHistory(historyData) {
           .map((x) => parseInt(x, 10))
       ) || undefined,
     exp: x[1] || 0,
-    totalExp: Object.values(historyData)
-      .slice(0, index + 1)
-      .reduce((pV, cV) => pV + cV, 0)
+    totalExp: maxToIndex(index)
   }));
 }
 

--- a/src/utils/Guild.js
+++ b/src/utils/Guild.js
@@ -9,7 +9,6 @@ function parseDate(date) {
 
 function parseHistory(historyData) {
   const expValuesReversed = Object.values(historyData).reverse();
-
   return Object.entries(historyData).map((x, index) => ({
     day: x[0],
     date:
@@ -20,9 +19,7 @@ function parseHistory(historyData) {
           .map((x) => parseInt(x, 10))
       ) || undefined,
     exp: x[1] || 0,
-    totalExp: expValuesReversed
-      .slice(0, expValuesReversed.length - index)
-      .reduce((pV, cV) => pV + cV)
+    totalExp: expValuesReversed.slice(0, expValuesReversed.length - index).reduce((pV, cV) => pV + cV)
   }));
 }
 

--- a/src/utils/Guild.js
+++ b/src/utils/Guild.js
@@ -11,7 +11,7 @@ function parseHistory(historyData) {
   const expValuesReversed = Object.values(historyData).reverse();
   const maxToIndex = (index) => {
       return expValuesReversed.slice(0, expValuesReversed.length - index).reduce((pV, cV) => pV + cV);
-  }
+  };
 
   return Object.entries(historyData).map((x, index) => ({
     day: x[0],


### PR DESCRIPTION
## Changes
src\utils\Guild.js incorrectly ordered how its total expHistory(s) were given across a users 7 day history. This fixed that so the most recent day shows the maximum the player has earned throughout the week and descending each day, Original one calculated from earliest to latest, so the first would erroneously start at 0


<details>
<summary>Screenshots</summary>
N/A
</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [ ] I've added jsdoc and typings.
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one) [Bug Report](https://discord.com/channels/660416184252104705/1277155283797413970)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`npm run tests`)
- [x] I've check for issues. (`npm run eslint`)
- [x] I've fixed my formatting. (`npm run prettier`)

</details>
