### PR TITLE
Rename Slayer Kill Tier Names to match Ingame

### DIFF
--- a/src/Structures/SkyBlock/Member/Slayers/SkyBlockMemberSlayer.test.ts
+++ b/src/Structures/SkyBlock/Member/Slayers/SkyBlockMemberSlayer.test.ts
@@ -10,8 +10,6 @@ test('SkyBlockMemberSlayer', () => {
   expectTypeOf(data).toEqualTypeOf<SkyBlockMemberSlayer>();
   expect(data.claimedLevels).toBeDefined();
   expectTypeOf(data.claimedLevels).toEqualTypeOf<SkyBlockMemberSlayerClaimedLevels>();
-  expect(data.tier0Kills).toBeDefined();
-  expectTypeOf(data.tier0Kills).toEqualTypeOf<number>();
   expect(data.tier1Kills).toBeDefined();
   expectTypeOf(data.tier1Kills).toEqualTypeOf<number>();
   expect(data.tier2Kills).toBeDefined();
@@ -20,6 +18,8 @@ test('SkyBlockMemberSlayer', () => {
   expectTypeOf(data.tier3Kills).toEqualTypeOf<number>();
   expect(data.tier4Kills).toBeDefined();
   expectTypeOf(data.tier4Kills).toEqualTypeOf<number>();
+  expect(data.tier5Kills).toBeDefined();
+  expectTypeOf(data.tier5Kills).toEqualTypeOf<number>();
   expect(data.level).toBeDefined();
   expectTypeOf(data.level).toEqualTypeOf<LevelData>();
 });

--- a/src/Structures/SkyBlock/Member/Slayers/SkyBlockMemberSlayer.ts
+++ b/src/Structures/SkyBlock/Member/Slayers/SkyBlockMemberSlayer.ts
@@ -4,19 +4,19 @@ import type { LevelData, SkyBlockSlayer } from '../../../../Types/SkyBlock.js';
 
 class SkyBlockMemberSlayer {
   claimedLevels: SkyBlockMemberSlayerClaimedLevels;
-  tier0Kills: number;
   tier1Kills: number;
   tier2Kills: number;
   tier3Kills: number;
   tier4Kills: number;
+  tier5Kills: number;
   level: LevelData;
   constructor(data: Record<string, any>, slayer: SkyBlockSlayer) {
     this.claimedLevels = new SkyBlockMemberSlayerClaimedLevels(data?.claimed_levels || {});
-    this.tier0Kills = data?.boss_kills_tier_0 || 0;
-    this.tier1Kills = data?.boss_kills_tier_1 || 0;
-    this.tier2Kills = data?.boss_kills_tier_2 || 0;
-    this.tier3Kills = data?.boss_kills_tier_3 || 0;
-    this.tier4Kills = data?.boss_kills_tier_4 || 0;
+    this.tier1Kills = data?.boss_kills_tier_0 || 0;
+    this.tier2Kills = data?.boss_kills_tier_1 || 0;
+    this.tier3Kills = data?.boss_kills_tier_2 || 0;
+    this.tier4Kills = data?.boss_kills_tier_3 || 0;
+    this.tier5Kills = data?.boss_kills_tier_4 || 0;
     this.level = getSlayerLevel(slayer, data?.xp);
   }
 


### PR DESCRIPTION
## Changes

Renames the slayer kill tiers to match the ingame tiers. There is no tier 0 ingame, but Tier 5:
<img width="425" height="371" alt="image" src="https://github.com/user-attachments/assets/ed88cf03-4913-460f-b2e4-aab2b43751c0" />
<img width="548" height="540" alt="image" src="https://github.com/user-attachments/assets/db3aa6f2-8d35-4908-bb56-20faf3a22d20" />


- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [ ] I've check for issues. (`pnpm lint`)
- [ ] I've fixed my formatting. (`pnpm prettier`)

</details>
