### PR TITLE
fix(getSkyBlockProfiles): fetching garden & museum while either are disabled

### DIFF
--- a/src/API/getSkyBlockProfile.ts
+++ b/src/API/getSkyBlockProfile.ts
@@ -12,8 +12,8 @@ class getSkyBlockProfile extends Endpoint {
     const res = await this.client.requestHandler.request(`/skyblock/profile?profile=${profileId}`, options);
     if (res.options.raw) return res;
     if (!res.data.profile) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
-    const garden = await this.handleGettingSkyBlockGarden(res.data.profile.profile_id);
-    const museum = await this.handleGettingSkyBlockMuseum(res.data.profile.profile_id);
+    const garden = options?.museum ? await this.handleGettingSkyBlockGarden(res.data.profile.profile_id) : null;
+    const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(res.data.profile.profile_id) : null;
     const parsedProfile = new SkyBlockProfile(res.data.profile, { uuid: null, garden, museum });
     return parsedProfile;
   }

--- a/src/API/getSkyBlockProfile.ts
+++ b/src/API/getSkyBlockProfile.ts
@@ -12,8 +12,8 @@ class getSkyBlockProfile extends Endpoint {
     const res = await this.client.requestHandler.request(`/skyblock/profile?profile=${profileId}`, options);
     if (res.options.raw) return res;
     if (!res.data.profile) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
-    const garden = options?.museum ? await this.handleGettingSkyBlockGarden(res.data.profile.profile_id) : null;
-    const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(res.data.profile.profile_id) : null;
+    const garden = options?.museum ? await this.handleGettingSkyBlockGarden(res.data.profile.profile_id) : undefined;
+    const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(res.data.profile.profile_id) : undefined;
     const parsedProfile = new SkyBlockProfile(res.data.profile, { uuid: null, garden, museum });
     return parsedProfile;
   }

--- a/src/API/getSkyBlockProfiles.ts
+++ b/src/API/getSkyBlockProfiles.ts
@@ -19,8 +19,8 @@ class getSkyBlockProfiles extends Endpoint {
     if (!res.data.profiles || !res.data.profiles.length) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
     const profiles: Map<SkyBlockProfileName | 'UNKNOWN', SkyBlockProfile> = new Map();
     for (const profile of res.data.profiles) {
-      const garden = options?.garden != false ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
-      const museum = options?.museum != false ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
+      const garden = options?.garden !== false ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
+      const museum = options?.museum !== false ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
       const parsedProfile = new SkyBlockProfile(profile, { uuid: query, garden, museum });
       profiles.set(parsedProfile.profileName, parsedProfile);
     }

--- a/src/API/getSkyBlockProfiles.ts
+++ b/src/API/getSkyBlockProfiles.ts
@@ -19,8 +19,8 @@ class getSkyBlockProfiles extends Endpoint {
     if (!res.data.profiles || !res.data.profiles.length) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
     const profiles: Map<SkyBlockProfileName | 'UNKNOWN', SkyBlockProfile> = new Map();
     for (const profile of res.data.profiles) {
-      const garden = options?.garden !== false ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
-      const museum = options?.museum !== false ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
+      const garden = options?.garden === true ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
+      const museum = options?.museum === true ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
       const parsedProfile = new SkyBlockProfile(profile, { uuid: query, garden, museum });
       profiles.set(parsedProfile.profileName, parsedProfile);
     }

--- a/src/API/getSkyBlockProfiles.ts
+++ b/src/API/getSkyBlockProfiles.ts
@@ -19,8 +19,8 @@ class getSkyBlockProfiles extends Endpoint {
     if (!res.data.profiles || !res.data.profiles.length) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
     const profiles: Map<SkyBlockProfileName | 'UNKNOWN', SkyBlockProfile> = new Map();
     for (const profile of res.data.profiles) {
-      const garden = options?.garden ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
-      const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
+      const garden = options?.garden ? await this.handleGettingSkyBlockGarden(profile.profile_id) : undefined;
+      const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : undefined;
       const parsedProfile = new SkyBlockProfile(profile, { uuid: query, garden, museum });
       profiles.set(parsedProfile.profileName, parsedProfile);
     }

--- a/src/API/getSkyBlockProfiles.ts
+++ b/src/API/getSkyBlockProfiles.ts
@@ -19,8 +19,8 @@ class getSkyBlockProfiles extends Endpoint {
     if (!res.data.profiles || !res.data.profiles.length) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
     const profiles: Map<SkyBlockProfileName | 'UNKNOWN', SkyBlockProfile> = new Map();
     for (const profile of res.data.profiles) {
-      const garden = options?.garden === true ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
-      const museum = options?.museum === true ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
+      const garden = options?.garden ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
+      const museum = options?.museum ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
       const parsedProfile = new SkyBlockProfile(profile, { uuid: query, garden, museum });
       profiles.set(parsedProfile.profileName, parsedProfile);
     }

--- a/src/API/getSkyBlockProfiles.ts
+++ b/src/API/getSkyBlockProfiles.ts
@@ -19,8 +19,8 @@ class getSkyBlockProfiles extends Endpoint {
     if (!res.data.profiles || !res.data.profiles.length) throw new Error(Errors.NO_SKYBLOCK_PROFILES);
     const profiles: Map<SkyBlockProfileName | 'UNKNOWN', SkyBlockProfile> = new Map();
     for (const profile of res.data.profiles) {
-      const garden = await this.handleGettingSkyBlockGarden(profile.profile_id);
-      const museum = await this.handleGettingSkyBlockMuseum(profile.profile_id);
+      const garden = options?.garden != false ? await this.handleGettingSkyBlockGarden(profile.profile_id) : null;
+      const museum = options?.museum != false ? await this.handleGettingSkyBlockMuseum(profile.profile_id) : null;
       const parsedProfile = new SkyBlockProfile(profile, { uuid: query, garden, museum });
       profiles.set(parsedProfile.profileName, parsedProfile);
     }


### PR DESCRIPTION
## Changes

Fixed `getSkyBlockProfiles` to not fetch skyblock museum and garden depending on whether garden or museum options is false:

```ts
const profiles = await hypixel
  .getSkyBlockProfiles("uuid", {
    garden: false,
    museum: false,
  });
```

Previously it would fetch museum and garden even when false.

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [x] I've check for issues. (`pnpm lint`)
- [x] I've fixed my formatting. (`pnpm prettier`)

</details>