### PR TITLE
fix(RequestHandler): cache by default

### DIFF
--- a/src/Private/RequestHandler.ts
+++ b/src/Private/RequestHandler.ts
@@ -24,7 +24,7 @@ class RequestHandler {
       noCache: options?.noCache ?? false,
       noCacheCheck: options?.noCacheCheck ?? false
     };
-    if (options.noCacheCheck && this.client.cacheHandler.has(endpoint)) {
+    if (!options.noCacheCheck && this.client.cacheHandler.has(endpoint)) {
       const data = this.client.cacheHandler.get(endpoint);
       return new RequestData(data.data, data.headers, {
         status: 200,

--- a/src/Private/RequestHandler.ts
+++ b/src/Private/RequestHandler.ts
@@ -71,7 +71,7 @@ class RequestHandler {
       cached: false
     });
     if (options.noCache) return requestData;
-    if (this.client.options.cache && !options.raw) {
+    if (this.client.options.cache) {
       this.client.cacheHandler.set(endpoint, requestData);
     }
     return requestData;


### PR DESCRIPTION
## Changes

After 42581420de3bec3df082793d44ba5e250424b576 requests stopped being cached unless `noCacheCheck` was set to true, which seems wrong. It should cache by default, unless `noCacheCheck` is set to true in which case it shouldn't check the cache.

<details>
<summary>Screenshots</summary>
<!-- 
  Screenshots of the code running (if applicable)
  Including these screenshots will assist the reviewing and speeding up the process
-->

</details>

<details>
<summary>Checkboxes</summary>

- [ ] I've added new features. (methods or parameters)
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [x] I've check for issues. (`pnpm lint`)
- [x] I've fixed my formatting. (`pnpm prettier`)

</details>
