### PR TITLE
add skywars/bedwars modes and fix kdr calculations

### DIFF
--- a/src/Structures/MiniGames/BedWars/BedWars.ts
+++ b/src/Structures/MiniGames/BedWars/BedWars.ts
@@ -71,6 +71,7 @@ class BedWars extends BedWarsMode {
   fourThree: BedWarsFourThree;
   fourFour: BedWarsFourFour;
   twoFour: BedWarsTwoFour;
+  castle: BedWarsMode;
   constructor(data: Record<string, any>) {
     super(data);
     this.experience = data?.Experience || 0;
@@ -113,6 +114,7 @@ class BedWars extends BedWarsMode {
     this.fourThree = new BedWarsFourThree(data || {});
     this.fourFour = new BedWarsFourFour(data || {});
     this.twoFour = new BedWarsTwoFour(data || {});
+    this.castle = new BedWarsMode(data, 'castle');
   }
 
   static getPrestige(level: number): BedWarsPrestige {

--- a/src/Structures/MiniGames/BedWars/BedWarsKillsDeaths/BedWarsKillsDeathsType.ts
+++ b/src/Structures/MiniGames/BedWars/BedWarsKillsDeaths/BedWarsKillsDeathsType.ts
@@ -6,9 +6,10 @@ class BedWarsKillsDeathsType extends BaseKillsDeathsType {
   constructor(data: Record<string, any>, type?: BedWarsFinalType, mode?: BedWarsModeId, finals: boolean = false) {
     type = ParseModeBefore(type) as BedWarsFinalType;
     mode = ParseModeBefore(mode) as BedWarsModeId;
-    super(data);
-    this.kills = data?.[`${mode}${type}${finals ? 'final_' : ''}kills_bedwars`] || 0;
-    this.deaths = data?.[`${mode}${type}${finals ? 'final_' : ''}deaths_bedwars`] || 0;
+    super({
+      kills: data?.[`${mode}${type}${finals ? 'final_' : ''}kills_bedwars`] || 0,
+      deaths: data?.[`${mode}${type}${finals ? 'final_' : ''}deaths_bedwars`] || 0
+    });
   }
 }
 

--- a/src/Structures/MiniGames/SkyWars/SkyWars.ts
+++ b/src/Structures/MiniGames/SkyWars/SkyWars.ts
@@ -66,6 +66,7 @@ class SkyWars extends SkyWarsMode {
   teams: SkyWarsTeams;
   mega: SkyWarsMega;
   mini: SkyWarsMini;
+  ranked: SkyWarsMode;
   constructor(data: Record<string, any>) {
     super(data);
     this.activeKillEffect = data?.active_killeffect || 'UNKNOWN';
@@ -124,6 +125,7 @@ class SkyWars extends SkyWarsMode {
     this.teams = new SkyWarsTeams(data);
     this.mega = new SkyWarsMega(data);
     this.mini = new SkyWarsMini(data);
+    this.ranked = new SkyWarsMode(data, 'ranked');
   }
 
   // Credit: https://github.com/Statsify/statsify/blob/main/packages/schemas/src/player/gamemodes/skywars/util.ts#L27-L38

--- a/src/Structures/MiniGames/SkyWars/SkyWarsKillsDeathsType.ts
+++ b/src/Structures/MiniGames/SkyWars/SkyWarsKillsDeathsType.ts
@@ -6,9 +6,7 @@ class SkyWarsKillsDeathsType extends BaseKillsDeathsType {
   constructor(data: Record<string, any>, type?: SkyWarsKillType, mode?: SkyWarsModeId | SkyWarsKitId) {
     type = ParseModeBefore(type) as SkyWarsKillType;
     mode = ParseModeAfter(mode) as SkyWarsModeId;
-    super(data);
-    this.kills = data?.[`${type}kills${mode}`] || 0;
-    this.deaths = data?.[`${type}kills${mode}`] || 0;
+    super({ kills: data?.[`${type}kills${mode}`] || 0, deaths: data?.[`${type}deaths${mode}`] || 0 });
   }
 }
 

--- a/src/Utils/ParseMode.ts
+++ b/src/Utils/ParseMode.ts
@@ -3,7 +3,7 @@ export function ParseModeBefore(mode?: string): string {
 }
 
 export function ParseModeAfter(mode?: string): string {
-  return mode && mode.trim() !== '' ? `_${mode.replace(/_$/, '')}` : '';
+  return mode && mode.trim() !== '' ? `_${mode.replace(/^_|_$/g, '')}` : '';
 }
 
 export function ParseModeBeforeAfter(mode?: string): string {


### PR DESCRIPTION
## Changes

- Fixed parsing issue that was creating double underscores in SkyWars mode names
- Fixed KDR calculation for **SkyWars modes** detailed statistics
- Fixed KDR calculation for **BedWars modes** detailed statistics
- Added support for the **SkyWars ranked** game mode
- Added support for the **BedWars castle** game mode

<details>
<summary>Checkboxes</summary>

- [x] I've added new features.
- [x] I've fixed bug. 
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [x] I've check for issues. (`pnpm lint`)
- [x] I've fixed my formatting. (`pnpm prettier`)

</details>