### PR TITLE
Fix BedWars and SkyWars kills/deaths/kdr parsing and calculations

### DIFF
--- a/src/Structures/MiniGames/BedWars/BedWarsKillsDeaths/BedWarsKillsDeathsType.ts
+++ b/src/Structures/MiniGames/BedWars/BedWarsKillsDeaths/BedWarsKillsDeathsType.ts
@@ -6,9 +6,10 @@ class BedWarsKillsDeathsType extends BaseKillsDeathsType {
   constructor(data: Record<string, any>, type?: BedWarsFinalType, mode?: BedWarsModeId, finals: boolean = false) {
     type = ParseModeBefore(type) as BedWarsFinalType;
     mode = ParseModeBefore(mode) as BedWarsModeId;
-    super(data);
-    this.kills = data?.[`${mode}${type}${finals ? 'final_' : ''}kills_bedwars`] || 0;
-    this.deaths = data?.[`${mode}${type}${finals ? 'final_' : ''}deaths_bedwars`] || 0;
+    super({
+      kills: data?.[`${mode}${type}${finals ? 'final_' : ''}kills_bedwars`] || 0,
+      deaths: data?.[`${mode}${type}${finals ? 'final_' : ''}deaths_bedwars`] || 0
+    });
   }
 }
 

--- a/src/Structures/MiniGames/SkyWars/SkyWarsKillsDeathsType.ts
+++ b/src/Structures/MiniGames/SkyWars/SkyWarsKillsDeathsType.ts
@@ -6,9 +6,7 @@ class SkyWarsKillsDeathsType extends BaseKillsDeathsType {
   constructor(data: Record<string, any>, type?: SkyWarsKillType, mode?: SkyWarsModeId | SkyWarsKitId) {
     type = ParseModeBefore(type) as SkyWarsKillType;
     mode = ParseModeAfter(mode) as SkyWarsModeId;
-    super(data);
-    this.kills = data?.[`${type}kills${mode}`] || 0;
-    this.deaths = data?.[`${type}kills${mode}`] || 0;
+    super({ kills: data?.[`${type}kills${mode}`] || 0, deaths: data?.[`${type}deaths${mode}`] || 0 });
   }
 }
 

--- a/src/Utils/ParseMode.ts
+++ b/src/Utils/ParseMode.ts
@@ -3,7 +3,7 @@ export function ParseModeBefore(mode?: string): string {
 }
 
 export function ParseModeAfter(mode?: string): string {
-  return mode && mode.trim() !== '' ? `_${mode.replace(/_$/, '')}` : '';
+  return mode && mode.trim() !== '' ? `_${mode.replace(/^_|_$/g, '')}` : '';
 }
 
 export function ParseModeBeforeAfter(mode?: string): string {


### PR DESCRIPTION
## Changes

- Fixed parsing issue that was creating double underscores in SkyWars mode names and prevented from getting kills and deaths data for SkyWars
- Fixed KDR calculation for SkyWars and BedWars modes detailed statistics

<details>
<summary>Checkboxes</summary>

- [] I've added new features.
- [x] I've fixed bug. 
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [x] I've check for issues. (`pnpm lint`)
- [x] I've fixed my formatting. (`pnpm prettier`)

</details>