### PR TITLE
add hunting skill + foraging above 50

### DIFF
--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -2279,6 +2279,8 @@ test('Client#getSkyBlockSkills', async () => {
   expectTypeOf(data.parsed.alchemy).toEqualTypeOf<SkyBlockSkill>();
   expect(data.parsed.carpentry).toBeDefined();
   expectTypeOf(data.parsed.carpentry).toEqualTypeOf<SkyBlockSkill>();
+  expect(data.parsed.hunting).toBeDefined();
+  expectTypeOf(data.parsed.hunting).toEqualTypeOf<SkyBlockSkill>();
   expect(data.parsed.runecrafting).toBeDefined();
   expectTypeOf(data.parsed.runecrafting).toEqualTypeOf<SkyBlockSkill>();
   expect(data.parsed.social).toBeDefined();

--- a/src/Structures/SkyBlock/Garden/SkyBlockGardenCropMilestones.ts
+++ b/src/Structures/SkyBlock/Garden/SkyBlockGardenCropMilestones.ts
@@ -1,4 +1,4 @@
-import { getLevelByXp } from '../../../Utils/index.js';
+import { CalculateAverage, getLevelByXp } from '../../../Utils/index.js';
 import type { SkillLevelData } from '../../../Types/index.js';
 
 class SkyBlockGardenCropMilestones {
@@ -15,7 +15,6 @@ class SkyBlockGardenCropMilestones {
   moonFlower: SkillLevelData;
   sunFlower: SkillLevelData;
   wildRose: SkillLevelData;
-  average: number;
   constructor(data: Record<string, any>) {
     this.wheat = getLevelByXp(data?.WHEAT ?? 0, { type: 'wheat' });
     this.carrot = getLevelByXp(data?.CARROT_ITEM ?? 0, { type: 'carrot' });
@@ -30,21 +29,10 @@ class SkyBlockGardenCropMilestones {
     this.moonFlower = getLevelByXp(data?.MOONFLOWER ?? 0, { type: 'moonFlower' });
     this.sunFlower = getLevelByXp(data?.DOUBLE_PLANT ?? 0, { type: 'sunFlower' });
     this.wildRose = getLevelByXp(data?.WILD_ROSE ?? 0, { type: 'wildRose' });
-    this.average =
-      (this.wheat.level +
-        this.carrot.level +
-        this.sugarCane.level +
-        this.potato.level +
-        this.pumpkin.level +
-        this.melon.level +
-        this.cactus.level +
-        this.cocoaBeans.level +
-        this.mushroom.level +
-        this.netherWart.level +
-        this.moonFlower.level +
-        this.sunFlower.level +
-        this.wildRose.level) /
-      13;
+  }
+
+  get average(): number {
+    return CalculateAverage(Object.values(this).map((value) => value.level));
   }
 
   toString(): number {

--- a/src/Structures/SkyBlock/Garden/SkyBlockGardenCropsUpgrades.ts
+++ b/src/Structures/SkyBlock/Garden/SkyBlockGardenCropsUpgrades.ts
@@ -1,3 +1,5 @@
+import { CalculateAverage } from '../../../Utils/numberUtils.ts';
+
 class SkyBlockGardenCropsUpgrades {
   wheat: number;
   carrot: number;
@@ -9,7 +11,6 @@ class SkyBlockGardenCropsUpgrades {
   cocoaBeans: number;
   mushroom: number;
   netherWart: number;
-  average: number;
   constructor(data: Record<string, any>) {
     this.wheat = data?.WHEAT ?? 0;
     this.carrot = data?.CARROT_ITEM ?? 0;
@@ -21,18 +22,10 @@ class SkyBlockGardenCropsUpgrades {
     this.cocoaBeans = data?.['INK_SACK:3'] ?? 0;
     this.mushroom = data?.MUSHROOM_COLLECTION ?? 0;
     this.netherWart = data?.NETHER_STALK ?? 0;
-    this.average =
-      (this.wheat +
-        this.carrot +
-        this.sugarCane +
-        this.potato +
-        this.pumpkin +
-        this.melon +
-        this.cactus +
-        this.cocoaBeans +
-        this.mushroom +
-        this.netherWart) /
-      10;
+  }
+
+  get average(): number {
+    return CalculateAverage(Object.values(this));
   }
 
   toString(): number {

--- a/src/Structures/SkyBlock/Member/Dungeons/SkyBlockMemberDungeonsClasses.ts
+++ b/src/Structures/SkyBlock/Member/Dungeons/SkyBlockMemberDungeonsClasses.ts
@@ -1,4 +1,4 @@
-import { getLevelByXp } from '../../../../Utils/index.js';
+import { CalculateAverage, getLevelByXp } from '../../../../Utils/index.js';
 import type { DungeonClass, SkillLevelData } from '../../../../Types/index.js';
 
 class SkyBlockMemberDungeonsClasses {
@@ -8,7 +8,6 @@ class SkyBlockMemberDungeonsClasses {
   mage: SkillLevelData;
   archer: SkillLevelData;
   tank: SkillLevelData;
-  average: number;
   constructor(data: Record<string, any>) {
     this.selected = data?.selected_dungeon_class ?? 'UNKNOWN';
     this.healer = getLevelByXp(data?.player_classes?.healer?.experience ?? 0, { type: 'dungeoneering' });
@@ -16,7 +15,10 @@ class SkyBlockMemberDungeonsClasses {
     this.mage = getLevelByXp(data?.player_classes?.mage?.experience ?? 0, { type: 'dungeoneering' });
     this.archer = getLevelByXp(data?.player_classes?.archer?.experience ?? 0, { type: 'dungeoneering' });
     this.tank = getLevelByXp(data?.player_classes?.tank?.experience ?? 0, { type: 'dungeoneering' });
-    this.average = (this.healer.level + this.berserk.level + this.mage.level + this.archer.level + this.tank.level) / 5;
+  }
+
+  get average(): number {
+    return CalculateAverage(Object.values(this).map((value) => value.level));
   }
 
   toString(): DungeonClass | 'UNKNOWN' {

--- a/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerData.test.ts
+++ b/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerData.test.ts
@@ -6,7 +6,7 @@ import { expect, expectTypeOf, test } from 'vitest';
 import type { SkyBlockArea, SkyBlockPotionEffectName } from '../../../../Types/index.js';
 
 test('SkyBlockMemberPlayerData', () => {
-  const data = new SkyBlockMemberPlayerData({ stats: 'meow' }, { farmingCap: 0, tamingCap: 0 });
+  const data = new SkyBlockMemberPlayerData({ stats: 'meow' }, { farmingCap: 0, tamingCap: 0, foragingCap: 0 });
   expect(data).toBeDefined();
   expect(data).toBeInstanceOf(SkyBlockMemberPlayerData);
   expectTypeOf(data).toEqualTypeOf<SkyBlockMemberPlayerData>();

--- a/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerData.ts
+++ b/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerData.ts
@@ -19,7 +19,7 @@ class SkyBlockMemberPlayerData {
   fastestTargetPractice: number;
   fishingTreasureCaught: number;
   skills: SkyBlockMemberPlayerDataSkills;
-  constructor(data: Record<string, any>, skillCaps: { farmingCap: number; tamingCap: number }) {
+  constructor(data: Record<string, any>, skillCaps: { farmingCap: number; tamingCap: number; foragingCap: number }) {
     this.activeEffects = (data?.active_effects ?? []).map(
       (effect: Record<string, any>) => new SkyBlockMemberPlayerDataActiveEffect(effect)
     );

--- a/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.test.ts
+++ b/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.test.ts
@@ -3,7 +3,7 @@ import { expect, expectTypeOf, test } from 'vitest';
 import type { SkillLevelData } from '../../../../Types/index.js';
 
 test('SkyBlockMemberPlayerDataSkills', () => {
-  const data = new SkyBlockMemberPlayerDataSkills({ stats: 'meow' }, { farmingCap: 0, tamingCap: 0 });
+  const data = new SkyBlockMemberPlayerDataSkills({ stats: 'meow' }, { farmingCap: 0, tamingCap: 0, foragingCap: 0 });
   expect(data).toBeDefined();
   expect(data).toBeInstanceOf(SkyBlockMemberPlayerDataSkills);
   expectTypeOf(data).toEqualTypeOf<SkyBlockMemberPlayerDataSkills>();
@@ -27,6 +27,8 @@ test('SkyBlockMemberPlayerDataSkills', () => {
   expectTypeOf(data.social).toEqualTypeOf<SkillLevelData>();
   expect(data.carpentry).toBeDefined();
   expectTypeOf(data.carpentry).toEqualTypeOf<SkillLevelData>();
+  expect(data.hunting).toBeDefined();
+  expectTypeOf(data.hunting).toEqualTypeOf<SkillLevelData>();
   expect(data.combat).toBeDefined();
   expectTypeOf(data.combat).toEqualTypeOf<SkillLevelData>();
   expect(data.average).toBeDefined();

--- a/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.ts
+++ b/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.ts
@@ -13,9 +13,11 @@ class SkyBlockMemberPlayerDataSkills {
   social: SkillLevelData;
   carpentry: SkillLevelData;
   combat: SkillLevelData;
+  hunting: SkillLevelData;
+  foragingCaps: number;
   average: number;
   nonCosmeticAverage: number;
-  constructor(data: Record<string, any>, skillCaps: { farmingCap: number; tamingCap: number }) {
+  constructor(data: Record<string, any>, skillCaps: { farmingCap: number; tamingCap: number; foragingCap: number }) {
     this.fishing = getLevelByXp(data?.SKILL_FISHING ?? 0, { type: 'fishing' });
     this.alchemy = getLevelByXp(data?.SKILL_ALCHEMY ?? 0, { type: 'alchemy' });
     this.runecrafting = getLevelByXp(data?.SKILL_RUNECRAFTING ?? 0, { type: 'runecrafting' });
@@ -23,10 +25,12 @@ class SkyBlockMemberPlayerDataSkills {
     this.farming = getLevelByXp(data?.SKILL_FARMING ?? 0, { type: 'farming', cap: 50 + skillCaps.farmingCap });
     this.enchanting = getLevelByXp(data?.SKILL_ENCHANTING ?? 0, { type: 'enchanting' });
     this.taming = getLevelByXp(data?.SKILL_TAMING ?? 0, { type: 'taming', cap: 50 + skillCaps.tamingCap });
-    this.foraging = getLevelByXp(data?.SKILL_FORAGING ?? 0, { type: 'foraging' });
+    this.foraging = getLevelByXp(data?.SKILL_FORAGING ?? 0, { type: 'foraging', cap: 53 + skillCaps.foragingCap });
     this.social = getLevelByXp(data?.SKILL_SOCIAL ?? 0, { type: 'social' });
     this.carpentry = getLevelByXp(data?.SKILL_CARPENTRY ?? 0, { type: 'carpentry' });
     this.combat = getLevelByXp(data?.SKILL_COMBAT ?? 0, { type: 'combat' });
+    this.hunting = getLevelByXp(data?.SKILL_HUNTING ?? 0, { type: 'hunting' });
+    this.foragingCaps = data?.SKILL_FORAGING_extra_level_cap ?? 0;
     this.average =
       (this.fishing.level +
         this.alchemy.level +
@@ -38,8 +42,9 @@ class SkyBlockMemberPlayerDataSkills {
         this.foraging.level +
         this.social.level +
         this.carpentry.level +
-        this.combat.level) /
-      11;
+        this.combat.level +
+        this.hunting.level) /
+      12;
     this.nonCosmeticAverage =
       (this.fishing.level +
         this.alchemy.level +
@@ -49,8 +54,9 @@ class SkyBlockMemberPlayerDataSkills {
         this.taming.level +
         this.foraging.level +
         this.carpentry.level +
-        this.combat.level) /
-      9;
+        this.combat.level +
+        this.hunting.level) /
+      10;
   }
 
   toString(): number {

--- a/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.ts
+++ b/src/Structures/SkyBlock/Member/PlayerData/SkyBlockMemberPlayerDataSkills.ts
@@ -1,7 +1,9 @@
-import { getLevelByXp } from '../../../../Utils/index.js';
-import type { SkillLevelData } from '../../../../Types/index.js';
+import { CalculateAverage, getLevelByXp } from '../../../../Utils/index.js';
+import type { Skill, SkillLevelData } from '../../../../Types/index.js';
 
 class SkyBlockMemberPlayerDataSkills {
+  private nonSkillKeys: string[] = ['nonSkillKeys', 'cosmeticSkills', 'foragingCaps'];
+  private cosmeticSkills: Skill[] = ['runecrafting', 'social'];
   fishing: SkillLevelData;
   alchemy: SkillLevelData;
   runecrafting: SkillLevelData;
@@ -15,8 +17,6 @@ class SkyBlockMemberPlayerDataSkills {
   combat: SkillLevelData;
   hunting: SkillLevelData;
   foragingCaps: number;
-  average: number;
-  nonCosmeticAverage: number;
   constructor(data: Record<string, any>, skillCaps: { farmingCap: number; tamingCap: number; foragingCap: number }) {
     this.fishing = getLevelByXp(data?.SKILL_FISHING ?? 0, { type: 'fishing' });
     this.alchemy = getLevelByXp(data?.SKILL_ALCHEMY ?? 0, { type: 'alchemy' });
@@ -31,32 +31,23 @@ class SkyBlockMemberPlayerDataSkills {
     this.combat = getLevelByXp(data?.SKILL_COMBAT ?? 0, { type: 'combat' });
     this.hunting = getLevelByXp(data?.SKILL_HUNTING ?? 0, { type: 'hunting' });
     this.foragingCaps = data?.SKILL_FORAGING_extra_level_cap ?? 0;
-    this.average =
-      (this.fishing.level +
-        this.alchemy.level +
-        this.runecrafting.level +
-        this.mining.level +
-        this.farming.level +
-        this.enchanting.level +
-        this.taming.level +
-        this.foraging.level +
-        this.social.level +
-        this.carpentry.level +
-        this.combat.level +
-        this.hunting.level) /
-      12;
-    this.nonCosmeticAverage =
-      (this.fishing.level +
-        this.alchemy.level +
-        this.mining.level +
-        this.farming.level +
-        this.enchanting.level +
-        this.taming.level +
-        this.foraging.level +
-        this.carpentry.level +
-        this.combat.level +
-        this.hunting.level) /
-      10;
+  }
+
+  get average(): number {
+    return CalculateAverage(
+      Object.entries(this)
+        .filter(([key]) => !this.nonSkillKeys.includes(key))
+        .map(([key, value]) => value.level)
+    );
+  }
+
+  get nonCosmeticAverage(): number {
+    return CalculateAverage(
+      Object.entries(this)
+        .filter(([key]) => !this.nonSkillKeys.includes(key))
+        .filter(([key]) => !this.cosmeticSkills.includes(key as Skill))
+        .map(([key, value]) => value.level)
+    );
   }
 
   toString(): number {

--- a/src/Structures/SkyBlock/Member/SkyBlockMember.ts
+++ b/src/Structures/SkyBlock/Member/SkyBlockMember.ts
@@ -68,7 +68,8 @@ class SkyBlockMember {
     this.pets = new SkyBlockMemberPets({ ...(data?.pets_data ?? {}), ...(data?.player_stats?.pets ?? {}) });
     this.playerData = new SkyBlockMemberPlayerData(data?.player_data ?? {}, {
       farmingCap: this.jacobContests.perks.farmingLevelCap ?? 0,
-      tamingCap: this.pets.petCare.petsSacrificed.length ?? 0
+      tamingCap: this.pets.petCare.petsSacrificed.length ?? 0,
+      foragingCap: data?.player_data?.experience?.SKILL_FORAGING_extra_level_cap ?? 0
     });
     this.playerStats = new SkyBlockMemberPlayerStats(data?.player_stats ?? {});
     this.profileStats = new SkyBlockMemberProfile(data?.profile ?? {});

--- a/src/Structures/SkyBlock/Skills/SkyBlockSkills.test.ts
+++ b/src/Structures/SkyBlock/Skills/SkyBlockSkills.test.ts
@@ -39,6 +39,9 @@ test('SkyBlockSkills', () => {
   expect(data.carpentry).toBeDefined();
   expect(data.carpentry).toBeInstanceOf(SkyBlockSkill);
   expectTypeOf(data.carpentry).toEqualTypeOf<SkyBlockSkill>();
+  expect(data.hunting).toBeDefined();
+  expect(data.hunting).toBeInstanceOf(SkyBlockSkill);
+  expectTypeOf(data.hunting).toEqualTypeOf<SkyBlockSkill>();
   expect(data.runecrafting).toBeDefined();
   expect(data.runecrafting).toBeInstanceOf(SkyBlockSkill);
   expectTypeOf(data.runecrafting).toEqualTypeOf<SkyBlockSkill>();

--- a/src/Structures/SkyBlock/Skills/SkyBlockSkills.ts
+++ b/src/Structures/SkyBlock/Skills/SkyBlockSkills.ts
@@ -15,6 +15,7 @@ class SkyBlockSkills {
   runecrafting: SkyBlockSkill;
   social: SkyBlockSkill;
   taming: SkyBlockSkill;
+  hunting: SkyBlockSkill;
   constructor(data: Record<string, any>) {
     this.lastUpdated = data?.lastUpdated ?? 0;
     this.lastUpdatedAt = new Date(this.lastUpdated);
@@ -30,6 +31,7 @@ class SkyBlockSkills {
     this.runecrafting = new SkyBlockSkill(data?.skills?.RUNECRAFTING ?? {});
     this.social = new SkyBlockSkill(data?.skills?.SOCIAL ?? {});
     this.taming = new SkyBlockSkill(data?.skills?.TAMING ?? {});
+    this.hunting = new SkyBlockSkill(data?.skills?.HUNTING ?? {});
   }
 }
 

--- a/src/Types/SkyBlock.ts
+++ b/src/Types/SkyBlock.ts
@@ -55,7 +55,8 @@ export const Skills = [
   'taming',
   'carpentry',
   'runecrafting',
-  'social'
+  'social',
+  'hunting'
 ] as const;
 export type Skill = (typeof Skills)[number];
 

--- a/src/Utils/constants.ts
+++ b/src/Utils/constants.ts
@@ -416,6 +416,7 @@ export const DEFAULT_SKILL_CAPS: { [key in SkyBlockXPTable]: number } = {
   carpentry: 50,
   runecrafting: 25,
   social: 25,
+  hunting: 50,
   dungeoneering: 50,
   default: 0,
   mining_tree: 10,

--- a/src/Utils/numberUtils.test.ts
+++ b/src/Utils/numberUtils.test.ts
@@ -1,4 +1,4 @@
-import { Divide } from './index.js';
+import { CalculateAverage, Divide, TicksToMilliseconds } from './index.js';
 import { expect, expectTypeOf, test } from 'vitest';
 
 test('Divide', () => {
@@ -10,4 +10,22 @@ test('Divide', () => {
   expectTypeOf(Divide(0, 0)).toBeNumber();
   expect(Divide(-5, 10)).toBe(-0.5);
   expectTypeOf(Divide(-5, 10)).toBeNumber();
+});
+
+test('TicksToMilliseconds', () => {
+  expect(TicksToMilliseconds(1)).toBe(50);
+  expectTypeOf(TicksToMilliseconds(1)).toBeNumber();
+  expect(TicksToMilliseconds(20)).toBe(1000);
+  expectTypeOf(TicksToMilliseconds(20)).toBeNumber();
+  expect(TicksToMilliseconds(123)).toBe(6150);
+  expectTypeOf(TicksToMilliseconds(123)).toBeNumber();
+});
+
+test('CalculateAverage', () => {
+  expect(CalculateAverage([])).toBe(0);
+  expectTypeOf(CalculateAverage([])).toBeNumber();
+  expect(CalculateAverage([1, 2, 3, 4, 5])).toBe(3);
+  expectTypeOf(CalculateAverage([1, 2, 3, 4, 5])).toBeNumber();
+  expect(CalculateAverage([100, 156, 1, 487453, 67984532, 52431234, 0, 2, 1, 10])).toBe(12090348.9);
+  expectTypeOf(CalculateAverage([1, 2, 3, 4, 5])).toBeNumber();
 });

--- a/src/Utils/numberUtils.ts
+++ b/src/Utils/numberUtils.ts
@@ -7,3 +7,8 @@ export function Divide(a: number, b: number): number {
 export function TicksToMilliseconds(ticks: number): number {
   return (ticks / 20) * 1000;
 }
+
+export function CalculateAverage(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}

--- a/src/Utils/skyBlockUtils.ts
+++ b/src/Utils/skyBlockUtils.ts
@@ -129,6 +129,7 @@ export function getXpTable(type: SkyBlockXPTable): Record<number, number> {
     alchemy: DEFAULT_LEVELING_XP,
     taming: DEFAULT_LEVELING_XP,
     carpentry: DEFAULT_LEVELING_XP,
+    hunting: DEFAULT_LEVELING_XP,
     garden: GARDEN_XP,
     wheat: WHEAT,
     carrot: CARROT,


### PR DESCRIPTION
## Changes

- added hunting skill (maxed at 50)
- added foraging levels above 50, which work like the following:
1. cap without doing anything is 53 currently, but will be increased further in the future most likely
2. you can purchase up to 4 upgrades which increase your cap by 1 each
3. this value gets stored in SKILL_FORAGING_extra_level_cap 
4. problem with this is, that i cant access it via this.playerData.skills.foragingCaps, because its before skills' init

if theres another, better way to put the max cap, feel free to suggest something

tested it locally on my own profile and everything lines up, as can be seen in the screens

<details>
<summary>Screenshots</summary>

Output log:

<img width="368" height="218" alt="image" src="https://github.com/user-attachments/assets/2aa91509-e238-4717-ac47-974b68338324" />

Ingame non cosmetic skill Average: (matches perfectly)
<img width="361" height="235" alt="image" src="https://github.com/user-attachments/assets/6013d7e9-a5ce-4072-9e19-4c93cbf06ad6" />

Ingame Foraging level: (53+3 matches perfectly)
<img width="434" height="482" alt="image" src="https://github.com/user-attachments/assets/d7de3cf1-5e57-48f3-ba01-48ace2f9eadc" />

Ingame Hunting level: (matches perfectly)
<img width="404" height="351" alt="image" src="https://github.com/user-attachments/assets/3d97ec91-685d-4809-8fab-20474ef6fec6" />


</details>

<details>
<summary>Checkboxes</summary>

- [x] I've added new features. (methods or parameters)
- [x] I've fixed bug. (_optional_ you can mention a issue if there is one)
- [ ] I've corrected the spelling in README, documentation, etc.
- [x] I've tested my code. (`pnpm test`)
- [x] I've check for issues. (`pnpm eslint`)
- [x] I've fixed my formatting. (`pnpm prettier`)

</details>
